### PR TITLE
Param Type model and CommandLinePart error/warning state

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cwlts",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "TypeScript data model for Common Workflow Language",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cwlts",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "TypeScript data model for Common Workflow Language",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cwlts",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "TypeScript data model for Common Workflow Language",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -4,8 +4,6 @@
 rm -r lib/mappings
 rm -r lib/models
 rm -r lib/schemas
-rm lib/index.d.ts
-rm lib/index.js
 
 mkdir lib/schemas
 

--- a/src/mappings/d2sb/CommandInputParameter.ts
+++ b/src/mappings/d2sb/CommandInputParameter.ts
@@ -9,11 +9,14 @@ import {
 } from "./CommandInputSchema";
 import {CommandLineBinding} from "./CommandLineBinding";
 
+export type CommandInputParameterType = Datatype | CommandInputSchema | CommandInputArraySchema
+    | CommandInputMapSchema | CommandInputEnumSchema
+    | CommandInputRecordSchema | string | Array<Datatype
+    | CommandInputSchema | CommandInputArraySchema | CommandInputMapSchema
+    | CommandInputEnumSchema | CommandInputRecordSchema | string>;
+
 export interface CommandInputParameter extends InputParameter {
-    type?: Datatype | CommandInputSchema | CommandInputArraySchema | CommandInputMapSchema
-        | CommandInputEnumSchema | CommandInputRecordSchema | string | Array<Datatype
-        | CommandInputSchema | CommandInputArraySchema | CommandInputMapSchema
-        | CommandInputEnumSchema | CommandInputRecordSchema | string>;
+    type?: CommandInputParameterType;
     inputBinding?: CommandLineBinding;
     "sbg:category"?: string;
 }

--- a/src/mappings/d2sb/CommandOutputParameter.ts
+++ b/src/mappings/d2sb/CommandOutputParameter.ts
@@ -3,7 +3,10 @@ import {Datatype} from "./Datatype";
 import {CommandOutputSchema} from "./CommandOutputSchema";
 import {CommandOutputBinding} from "./CommandOutputBinding";
 
+export type CommandOutputParameterType = Datatype | CommandOutputSchema | string
+    | Array<Datatype | CommandOutputSchema | string>;
+
 export interface CommandOutputParameter extends OutputParameter {
-    type?: Datatype | CommandOutputSchema | string | Array<Datatype | CommandOutputSchema | string>;
+    type?: CommandOutputParameterType;
     outputBinding?: CommandOutputBinding;
 }

--- a/src/models/d2sb/CommandArgumentModel.ts
+++ b/src/models/d2sb/CommandArgumentModel.ts
@@ -2,12 +2,14 @@ import {CommandLineBinding} from "../../mappings/d2sb/CommandLineBinding";
 import {CommandLinePart} from "../helpers/CommandLinePart";
 import {CommandLineInjectable} from "../interfaces/CommandLineInjectable";
 import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
+import {ValidationBase} from "../helpers/validation/ValidationBase";
 
-export class CommandArgumentModel implements CommandLineInjectable {
+export class CommandArgumentModel extends ValidationBase implements CommandLineInjectable {
     part: CommandLinePart;
     arg: string | CommandLineBinding;
 
-    constructor(arg: string | CommandLineBinding) {
+    constructor(loc: string, arg: string | CommandLineBinding) {
+        super(loc);
         this.arg = arg;
     }
 

--- a/src/models/d2sb/CommandArgumentModel.ts
+++ b/src/models/d2sb/CommandArgumentModel.ts
@@ -7,7 +7,15 @@ import {CommandLineBindingModel} from "./CommandLineBindingModel";
 import {Validation} from "../helpers/validation/Validation";
 
 export class CommandArgumentModel extends ValidationBase implements Serializable<string | CommandLineBinding>, CommandLineInjectable {
-    private arg: string;
+    get arg(): string|CommandLineBinding {
+        return this.stringVal || this.binding.serialize();
+    }
+
+    set arg(value: string|CommandLineBinding) {
+        this.deserialize(value);
+    }
+
+    private stringVal: string;
     private binding: CommandLineBindingModel;
 
     constructor(loc: string, arg?: string | CommandLineBinding) {
@@ -18,8 +26,8 @@ export class CommandArgumentModel extends ValidationBase implements Serializable
     public getCommandPart(job?: any, value?: any): CommandLinePart {
         if (typeof this.binding === "object") {
             return this.evaluate(job);
-        } else if (typeof this.arg === 'string') {
-            return new CommandLinePart(<string> this.arg, 0, "argument");
+        } else if (typeof this.stringVal === 'string') {
+            return new CommandLinePart(<string> this.stringVal, 0, "argument");
         }
     }
 
@@ -53,8 +61,8 @@ export class CommandArgumentModel extends ValidationBase implements Serializable
     public customProps: any = {};
 
     serialize(): string|CommandLineBinding {
-        if (this.arg) {
-            return this.arg;
+        if (this.stringVal) {
+            return this.stringVal;
         } else {
             return this.binding.serialize();
         }
@@ -62,7 +70,7 @@ export class CommandArgumentModel extends ValidationBase implements Serializable
 
     deserialize(attr: string|CommandLineBinding): void {
         if (typeof attr === "string") {
-            this.arg = attr;
+            this.stringVal = attr;
         } else {
             this.binding = new CommandLineBindingModel(this.loc, attr);
             this.binding.setValidationCallback((err:Validation) => {this.updateValidity(err);})

--- a/src/models/d2sb/CommandInputParameterModel.spec.ts
+++ b/src/models/d2sb/CommandInputParameterModel.spec.ts
@@ -1,6 +1,7 @@
 import {CommandInputParameterModel} from "./CommandInputParameterModel";
 import {expect} from "chai";
 import {CommandInputParameter} from "../../mappings/d2sb/CommandInputParameter";
+import {ExpressionClass} from "../../mappings/d2sb/Expression";
 
 describe("CommandInputParameterModel d2sb", () => {
 
@@ -514,13 +515,13 @@ describe("CommandInputParameterModel d2sb", () => {
                 inputBinding: {
                     prefix: "--prefix",
                     valueFrom: {
-                        'class': "Expression",
+                        'class': <ExpressionClass> "Expression",
                         engine: "#cwl-js-engine",
                         script: "{ return 3 + 3 + 3 }"
                     }
                 }
             };
-            const input = new CommandInputParameterModel("", <CommandInputParameter>data);
+            const input = new CommandInputParameterModel("", data);
             expect(input.serialize()).to.deep.equal(data);
         });
 

--- a/src/models/d2sb/CommandInputParameterModel.spec.ts
+++ b/src/models/d2sb/CommandInputParameterModel.spec.ts
@@ -489,4 +489,73 @@ describe("CommandInputParameterModel d2sb", () => {
         });
     });
 
+    describe("serialize", () => {
+        it("Should serialize simple type, label, description, inputBinding", () => {
+            const data  = {
+                type: ["string"],
+                label: "label",
+                description: "desc",
+                id: "hello",
+                inputBinding: {
+                    prefix: "--prefix"
+                }
+            };
+            const input = new CommandInputParameterModel("", <CommandInputParameter>data);
+            expect(input.serialize()).to.deep.equal(data);
+        });
+
+        it("Should serialize complex type, inputBinding with expression", () => {
+            const data  = {
+                type: [{
+                    type: "array",
+                    items: "string"
+                }],
+                id: "hello",
+                inputBinding: {
+                    prefix: "--prefix",
+                    valueFrom: {
+                        'class': "Expression",
+                        engine: "#cwl-js-engine",
+                        script: "{ return 3 + 3 + 3 }"
+                    }
+                }
+            };
+            const input = new CommandInputParameterModel("", <CommandInputParameter>data);
+            expect(input.serialize()).to.deep.equal(data);
+        });
+
+        it("Should serialize record type with fields", () => {
+            const data  = {
+                type: [{
+                    type: "record",
+                    name: "rec",
+                    fields: [
+                        {
+                            type: ["string"],
+                            id: "a",
+                            label: "field"
+                        }
+                    ]
+                }],
+                id: "b"
+            };
+            const input = new CommandInputParameterModel("", <CommandInputParameter>data);
+            expect(input.serialize()).to.deep.equal(data);
+        });
+
+        it("Should serialize with custom properties", () => {
+            const data = {
+                type: ["null", "string"],
+                id: "b",
+                "pref:customprop": "some value",
+                "pref:otherprop": {
+                    complex: "value"
+                }
+            };
+            const input = new CommandInputParameterModel("", <CommandInputParameter>data);
+            expect(input.serialize()).to.deep.equal(data);
+        });
+
+    });
+
 });

--- a/src/models/d2sb/CommandInputParameterModel.spec.ts
+++ b/src/models/d2sb/CommandInputParameterModel.spec.ts
@@ -238,12 +238,12 @@ describe("CommandInputParameterModel d2sb", () => {
                 }
             });
 
-            input.addField({
+            input.type.addField({
                 name: "field",
                 type: "string"
             });
 
-            expect(input.fields).to.have.length(1);
+            expect(input.type.fields).to.have.length(1);
         });
 
         // add field on non record input
@@ -257,12 +257,12 @@ describe("CommandInputParameterModel d2sb", () => {
             });
 
             expect(() => {
-                input.addField({
+                input.type.addField({
                     name: "field",
                     type: "string"
                 });
             }).to.throw;
-            expect(input.fields).to.be.null;
+            expect(input.type.fields).to.be.null;
         });
 
         // remove field
@@ -275,14 +275,14 @@ describe("CommandInputParameterModel d2sb", () => {
                 }
             });
 
-            input.addField({
+            input.type.addField({
                 name: "field",
                 type: "string"
             });
 
-            expect(input.fields).to.have.length(1);
-            input.removeField("field");
-            expect(input.fields).to.have.length(0);
+            expect(input.type.fields).to.have.length(1);
+            input.type.removeField("field");
+            expect(input.type.fields).to.have.length(0);
         });
 
         it("should remove an existing field by object", () => {
@@ -299,11 +299,11 @@ describe("CommandInputParameterModel d2sb", () => {
                 type: "string"
             });
 
-            input.addField(field);
+            input.type.addField(field);
 
-            expect(input.fields).to.have.length(1);
-            input.removeField(field);
-            expect(input.fields).to.have.length(0);
+            expect(input.type.fields).to.have.length(1);
+            input.type.removeField(field);
+            expect(input.type.fields).to.have.length(0);
         });
 
         // add field with duplicate name
@@ -316,13 +316,13 @@ describe("CommandInputParameterModel d2sb", () => {
                 }
             });
 
-            input.addField({
+            input.type.addField({
                 name: "field",
                 type: "string"
             });
 
             expect(() => {
-                input.addField({
+                input.type.addField({
                     name: "field",
                     type: "string"
                 });
@@ -339,14 +339,14 @@ describe("CommandInputParameterModel d2sb", () => {
                 }
             });
 
-            input.addField({
+            input.type.addField({
                 name: "field",
                 type: "string"
             });
 
-            expect(input.fields).to.have.length(1);
+            expect(input.type.fields).to.have.length(1);
             expect(() => {
-                input.removeField("boo");
+                input.type.removeField("boo");
             }).to.throw;
         });
     });
@@ -356,8 +356,8 @@ describe("CommandInputParameterModel d2sb", () => {
         it("should set type by string", () => {
             const input = new CommandInputParameterModel("");
 
-            input.setType("string");
-            expect(input.getType()).to.equal("string");
+            input.type.type = "string";
+            expect(input.type.type).to.equal("string");
         });
 
     });
@@ -370,8 +370,8 @@ describe("CommandInputParameterModel d2sb", () => {
                 type: {type: "array", items: "int"}
             });
 
-            input.setItems("string");
-            expect(input.items).to.equal("string");
+            input.type.items = "string";
+            expect(input.type.items).to.equal("string");
         });
 
         // set items type on non-array
@@ -382,25 +382,13 @@ describe("CommandInputParameterModel d2sb", () => {
             });
 
             expect(() => {
-                input.setItems("string");
+                input.type.items = "string";
             }).to.throw;
         });
     });
 
     describe("symbols", () => {
-        // add symbol
-
-        //
-    });
-
-    describe("toString", () => {
-        // json
-
-        // all the types
-
-        // yaml
-
-        // all the types
+        it("should add symbols")
     });
 
     describe("setValueFrom", () => {

--- a/src/models/d2sb/CommandInputParameterModel.ts
+++ b/src/models/d2sb/CommandInputParameterModel.ts
@@ -63,7 +63,7 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
     deserialize(input: CommandInputParameter | CommandInputRecordField): void {
         const serializedAttr = ["label", "description", "inputBinding", "type"];
 
-        input = input || {};
+        input = input || <CommandInputParameter | CommandInputRecordField>{};
 
         this.isField     = !!(<CommandInputRecordField> input).name; // record fields don't have ids
         this.isField ? serializedAttr.push("name") : serializedAttr.push("id");
@@ -187,6 +187,12 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
                         $job: job,
                         $self: ''
                     }, this.inputBinding);
+                if (this.inputBinding.valueFrom && this.inputBinding.valueFrom.validation.errors.length) {
+                    return new CommandLinePart(`<Error at ${this.inputBinding.valueFrom.loc}>`, [position, this.id], "error");
+                }
+                if (this.inputBinding.valueFrom && this.inputBinding.valueFrom.validation.warnings.length) {
+                    return new CommandLinePart(`<Warning at ${this.inputBinding.valueFrom.loc}>`, [position, this.id], "warning");
+                }
                 return new CommandLinePart(calcVal, [position, this.id], "input");
             } else {
                 return new CommandLinePart('', [position, this.id], "input");
@@ -200,6 +206,12 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
                 $job: job,
                 $self: value
             }, this.inputBinding);
+        if (this.inputBinding.valueFrom && this.inputBinding.valueFrom.validation.errors.length) {
+            return new CommandLinePart(`<Error at ${this.inputBinding.valueFrom.loc}>`, [position, this.id], "error");
+        }
+        if (this.inputBinding.valueFrom && this.inputBinding.valueFrom.validation.warnings.length) {
+            return new CommandLinePart(`<Warning at ${this.inputBinding.valueFrom.loc}>`, [position, this.id], "warning");
+        }
         return new CommandLinePart(calcVal, [position, this.id], "input");
     }
 

--- a/src/models/d2sb/CommandInputParameterModel.ts
+++ b/src/models/d2sb/CommandInputParameterModel.ts
@@ -231,8 +231,7 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
 
     public setValueFrom(value: string | Expression): void {
         if (!this.inputBinding) {
-            this.inputBinding = new CommandLineBindingModel(`${this.loc}.inputBinding`, {});
-            this.inputBinding.setValidationCallback((err: Validation) => this.updateValidity(err));
+            this.createInputBinding();
         }
         this.inputBinding.setValueFrom(value);
     }
@@ -241,12 +240,17 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
         return this.inputBinding ? this.inputBinding.valueFrom : undefined;
     }
 
-    public hasInputBinding(): boolean {
-        return this.inputBinding !== undefined && this.inputBinding !== null;
+    public createInputBinding() {
+        this.inputBinding = new CommandLineBindingModel(`${this.loc}.inputBinding`, {});
+        this.inputBinding.setValidationCallback((err: Validation) => this.updateValidity(err));
     }
 
     public removeInputBinding(): void {
         this.inputBinding = null;
+    }
+
+    public get isBound(): boolean {
+        return this.inputBinding !== undefined && this.inputBinding !== null;
     }
 
     //@todo(maya) implement validation

--- a/src/models/d2sb/CommandInputParameterModel.ts
+++ b/src/models/d2sb/CommandInputParameterModel.ts
@@ -1,16 +1,14 @@
 import {CommandInputParameter} from "../../mappings/d2sb/CommandInputParameter";
 import {CommandLineInjectable} from "../interfaces/CommandLineInjectable";
 import {CommandLinePart} from "../helpers/CommandLinePart";
-import {Datatype} from "../../mappings/d2sb/Datatype";
-import {MapType, EnumType, ArrayType, RecordType} from "../../mappings/d2sb/CommandInputSchema";
-import {CommandLineBinding} from "../../mappings/d2sb/CommandLineBinding";
-import {TypeResolver, TypeResolution} from "../helpers/TypeResolver";
+import {TypeResolver} from "../helpers/TypeResolver";
 import {CommandInputRecordField} from "../../mappings/d2sb/CommandInputRecordField";
 import {Expression} from "../../mappings/d2sb/Expression";
 import {Serializable} from "../interfaces/Serializable";
 import {CommandLineBindingModel} from "./CommandLineBindingModel";
 import {ExpressionModel} from "./ExpressionModel";
 import {ValidationBase, Validation} from "../helpers/validation";
+import {InputParameterTypeModel} from "./InputParameterTypeModel";
 
 export class CommandInputParameterModel extends ValidationBase implements Serializable<CommandInputParameter | CommandInputRecordField>, CommandLineInjectable {
     /** unique identifier of input */
@@ -20,43 +18,31 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
     /** Human readable, Markdown format description */
     public description: string;
 
-    /** Flag if input is required. Derived from type field */
-    public isRequired: boolean = true;
     /** Flag if input is field of a parent record. Derived from type field */
     public isField: boolean    = false;
 
-    /**
-     * Primitive type of input
-     * Complex types such as {type: "array", items: "string"}
-     * are flattened to this.type == "array"
-     * and this.items == "string"
-     */
-    public type: string = null;
-    /** Primitive type of items, if input is an array */
-    public items: string = null;
-    /** InputBinding defined for items inside of {type: "array"} object */
-    private itemsBinding: CommandLineBinding = null;
-    /** Fields mapped to InputParameterModel for easier command line generation */
-    public fields: Array<CommandInputParameterModel> = null;
-    /** Symbols defined in {type: "enum"} */
-    public symbols: Array<string>                    = null;
+    /** Complex object that holds logic and information about input's type property */
+    public type: InputParameterTypeModel;
 
     /** Binding for inclusion in command line */
     private inputBinding: CommandLineBindingModel = null;
 
-    /** name property in type object, only applicable for "enum" and "record" */
-    private typeName: string = null;
-
-
     public job: any; //@todo better way to set job?
 
     public self: any; //@todo calculate self based on id??
+
+    constructor(loc: string, input?: CommandInputParameter | CommandInputRecordField) {
+        super(loc);
+        this.deserialize(input);
+    }
 
     serialize(): CommandInputParameter | CommandInputRecordField {
         return undefined;
     }
 
     deserialize(input: CommandInputParameter | CommandInputRecordField): void {
+        input = input || {};
+
         this.isField     = !!(<CommandInputRecordField> input).name; // record fields don't have ids
         this.id          = (<CommandInputParameter> input).id
             || (<CommandInputRecordField> input).name || ""; // for record fields
@@ -71,31 +57,8 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
             this.inputBinding.setValidationCallback((err: Validation) => this.updateValidity(err));
         }
 
-        const resolved: TypeResolution = TypeResolver.resolveType(input.type);
-
-        this.type   = resolved.type;
-        this.fields = resolved.fields ? resolved.fields.map((field, index) => {
-            const f = new CommandInputParameterModel(`${this.loc}.fields[${index}]`, field);
-            f.setValidationCallback((err: Validation) => {
-                this.updateValidity(err);
-            });
-            return new CommandInputParameterModel(field);
-        }) : resolved.fields;
-
-        this.items      = resolved.items;
-        this.symbols    = resolved.symbols;
-        this.isRequired = resolved.isRequired;
-
-        this.itemsBinding = resolved.itemsBinding;
-        this.typeName = resolved.typeName;
-    }
-
-
-    constructor(loc: string, input?: CommandInputParameter | CommandInputRecordField) {
-        super(loc);
-        if (input) {
-            this.deserialize(input);
-        }
+        this.type = new InputParameterTypeModel(input.type, `${this.loc}.type`);
+        this.type.setValidationCallback((err: Validation) => { this.updateValidity(err) });
     }
 
     getCommandPart(job?: any, value?: any, self?: any): CommandLinePart {
@@ -106,11 +69,11 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
         }
 
         // If type declared does not match type of value, throw error
-        if (!TypeResolver.doesTypeMatch(this.type, value)) {
+        if (!TypeResolver.doesTypeMatch(this.type.type, value)) {
             // If there are items, only throw exception if items don't match either
-            if (!this.items || !TypeResolver.doesTypeMatch(this.items, value)) {
-                throw(`Mismatched value and type definition expected for ${this.id}. ${this.type} 
-                or ${this.items}, but instead got ${typeof value}`);
+            if (!this.type.items || !TypeResolver.doesTypeMatch(this.type.items, value)) {
+                throw(`Mismatched value and type definition expected for ${this.id}. ${this.type.type} 
+                or ${this.type.items}, but instead got ${typeof value}`);
             }
         }
 
@@ -119,8 +82,8 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
         const position      = this.inputBinding.position || 0;
         const itemSeparator = this.inputBinding.itemSeparator;
 
-        const itemsPrefix = (this.itemsBinding && this.itemsBinding.prefix)
-            ? this.itemsBinding.prefix : '';
+        const itemsPrefix = (this.type.typeBinding && this.type.typeBinding.prefix)
+            ? this.type.typeBinding.prefix : '';
 
         // array
         if (Array.isArray(value)) {
@@ -151,14 +114,14 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
                 // (itemPrefix) value3
             } else {
                 // booleans are a special
-                if (this.items === "boolean") {
+                if (this.type.items === "boolean") {
                     calcVal = prefix + separator + parts
                             .map(part => part.value)
                             .join(" ").trim();
                 } else {
                     const itemPrefSep = this.inputBinding.separate !== false ? " " : "";
-                    const joiner = !!itemsPrefix ? " " : "";
-                    calcVal = prefix + separator + parts
+                    const joiner      = !!itemsPrefix ? " " : "";
+                    calcVal           = prefix + separator + parts
                             .map(part => itemsPrefix + itemPrefSep + part.value)
                             .join(joiner).trim();
                 }
@@ -173,7 +136,7 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
             // make sure object isn't a file, resolve handles files
             if (!value.path) {
                 // evaluate record by calling generate part for each field
-                const parts = this.fields.map((field) => field.getCommandPart(job, value[field.id]));
+                const parts = this.type.fields.map((field) => field.getCommandPart(job, value[field.id]));
 
                 let calcVal: string = '';
 
@@ -188,8 +151,11 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
         // boolean should only include prefix and valueFrom (booleans === flags)
         if (typeof value === "boolean") {
             if (value) {
-                prefix        = this.items === "boolean" ? itemsPrefix : prefix;
-                const calcVal = prefix + separator + this.resolve({$job: job, $self: ''}, this.inputBinding);
+                prefix        = this.type.items === "boolean" ? itemsPrefix : prefix;
+                const calcVal = prefix + separator + this.resolve({
+                        $job: job,
+                        $self: ''
+                    }, this.inputBinding);
                 return new CommandLinePart(calcVal, [position, this.id], "input");
             } else {
                 return new CommandLinePart('', [position, this.id], "input");
@@ -198,8 +164,11 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
 
         // not record or array or boolean
         // if the input has items, this is a recursive call and prefix should not be added again
-        prefix        = this.items ? '' : prefix;
-        const calcVal = prefix + separator + this.resolve({$job: job, $self: value}, this.inputBinding);
+        prefix        = this.type.items ? '' : prefix;
+        const calcVal = prefix + separator + this.resolve({
+                $job: job,
+                $self: value
+            }, this.inputBinding);
         return new CommandLinePart(calcVal, [position, this.id], "input");
     }
 
@@ -215,110 +184,6 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
         }
 
         return value;
-    }
-
-    public setType(type: Datatype | EnumType | MapType | ArrayType | RecordType): void {
-        this.type = type;
-
-        switch (type) {
-            case "array":
-                this.symbols = null;
-                this.fields  = null;
-                break;
-            case "enum":
-                this.items  = null;
-                this.fields = null;
-                break;
-            case "record":
-                this.items   = null;
-                this.symbols = null;
-                break;
-        }
-    }
-
-    public getType(): string {
-        return this.type;
-    }
-
-    public setItems(type: Datatype | EnumType | MapType | ArrayType | RecordType): void {
-        if (this.type !== "array") {
-
-            throw("Items can only be set to inputs type Array");
-        } else {
-            this.items = type;
-        }
-    }
-
-    public getItems(): string {
-        return this.items;
-    }
-
-    public addField(field: CommandInputParameterModel | CommandInputParameter | CommandInputRecordField): void {
-        if (this.type !== "record" && this.items !== "record") {
-            throw(`Fields can only be added to type or items record: type is ${this.type}, items is ${this.items}.`);
-        } else {
-            const duplicate = this.fields.filter(val => {
-                return val.id === (<CommandInputRecordField> field).name
-                    || val.id === (<CommandInputParameter> field).id;
-            });
-            if (duplicate.length > 0) {
-                throw(`Field with name "${duplicate[0].id}" already exists`);
-            }
-
-            if (field instanceof CommandInputParameterModel) {
-                this.fields.push(field);
-            } else {
-                this.fields.push(new CommandInputParameterModel(`${this.loc}.fields[${this.fields.length}]`, <CommandInputRecordField>field));
-            }
-        }
-    }
-
-    public removeField(field: CommandInputParameterModel | string) {
-        let found;
-
-        if (typeof field === "string") {
-            found = this.fields.filter(val => val.id === field)[0];
-        } else {
-            found = field;
-        }
-
-        const index = this.fields.indexOf(found);
-        if (index < 0) {
-            throw(`Field ${field} does not exist on input`);
-        }
-
-        this.fields.splice(index, 1);
-    }
-
-    public addSymbol(symbol: string) {
-        if (this.type !== "enum" && this.items !== "enum") {
-            throw(`Items can only be set to inputs type array`);
-        }
-    }
-
-    public getLabel(): string {
-        return this.label;
-    }
-
-    public setLabel(label: string) {
-        this.label = label;
-    }
-
-    public getDescription(): string {
-        return this.description;
-    }
-
-    public setDescription(description: string) {
-        this.description = description;
-    }
-
-    //@todo(maya) implement serialization
-    public toString(format: string = 'json') {
-        if (format === 'json') {
-
-        } else if (format === 'yaml') {
-
-        }
     }
 
     public setValueFrom(value: string | Expression): void {
@@ -368,20 +233,20 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
 
         // check type
         // if array, has items. Does not have symbols or items
-        if (this.type === "array") {
-            if (this.items === null) {
+        if (this.type.type === "array") {
+            if (this.type.items === null) {
                 val.errors.push({
                     message: "Type array must have items",
                     loc: location
                 });
             }
-            if (this.symbols !== null) {
+            if (this.type.symbols !== null) {
                 val.errors.push({
                     message: "Type array must not have symbols",
                     loc: location
                 });
             }
-            if (this.fields !== null) {
+            if (this.type.fields !== null) {
                 val.errors.push({
                     message: "Type array must not have fields",
                     loc: location
@@ -389,27 +254,27 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
             }
         }
         // if enum, has symbols. Does not have items or fields. Has name.
-        if (this.type === "enum") {
-            if (this.items !== null) {
+        if (this.type.type === "enum") {
+            if (this.type.items !== null) {
                 val.errors.push({
                     message: "Type enum must not have items",
                     loc: location
                 });
             }
-            if (this.symbols === null) {
+            if (this.type.symbols === null) {
                 val.errors.push({
                     message: "Type enum must have symbols",
                     loc: location
                 });
             }
-            if (this.fields !== null) {
+            if (this.type.fields !== null) {
                 val.errors.push({
                     message: "Type enum must not have fields",
                     loc: location
                 });
             }
 
-            if (!this.typeName) {
+            if (!this.type.name) {
                 val.errors.push({
                     message: "Type enum must have a name",
                     loc: location
@@ -417,39 +282,30 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
             }
         }
         // if record, has fields. Does not have items or symbols. Has name.
-        if (this.type === "enum") {
-            if (this.items !== null) {
+        if (this.type.type === "enum") {
+            if (this.type.items !== null) {
                 val.errors.push({
                     message: "Type record must not have items",
                     loc: location
                 });
             }
-            if (this.symbols === null) {
+            if (this.type.symbols === null) {
                 val.errors.push({
                     message: "Type record must have symbols",
                     loc: location
                 });
             }
-            if (this.fields === null) {
+            if (this.type.fields === null) {
                 val.errors.push({
                     message: "Type record must have fields",
                     loc: location
                 });
             } else {
                 // check validity for each field.
-
-                // val.error.concat(this.fields.map(field => {
-                //     return field.validate().map((err, index) => {
-                //         err.location.replace(/<fieldIndex>/, index.toString());
-                //         err.location = "inputs[<inputIndex>]" + err.location;
-                //         return err;
-                //     });
-                // }).reduce((acc, curr) => acc.concat(curr)));
-
                 // @todo check uniqueness of each field name
             }
 
-            if (!this.typeName) {
+            if (!this.type.name) {
                 val.errors.push({
                     message: "Type record must have a name",
                     loc: location
@@ -457,7 +313,7 @@ export class CommandInputParameterModel extends ValidationBase implements Serial
             }
         }
 
-        const errors = this.validation.errors.concat(val.errors);
+        const errors   = this.validation.errors.concat(val.errors);
         const warnings = this.validation.warnings.concat(val.warnings);
 
         this.validation = {errors, warnings};

--- a/src/models/d2sb/CommandLineBindingModel.spec.ts
+++ b/src/models/d2sb/CommandLineBindingModel.spec.ts
@@ -1,6 +1,7 @@
 import {expect} from "chai";
 import {CommandLineBindingModel} from "./CommandLineBindingModel";
 import {CommandLineBinding} from "../../mappings/d2sb/CommandLineBinding";
+import {ExpressionClass} from "../../mappings/d2sb/Expression";
 
 describe("CommandLineBindingModel", () => {
     describe("updateValidity", () => {
@@ -25,12 +26,12 @@ describe("CommandLineBindingModel", () => {
         it("Should serialize binding with valueFrom", () => {
             const data    = {
                 valueFrom: {
-                    "class": "Expression",
+                    "class": <ExpressionClass> "Expression",
                     engine: "#cwl-js-engine",
                     script: "---"
                 }
             };
-            const binding = new CommandLineBindingModel("", <CommandLineBinding>data);
+            const binding = new CommandLineBindingModel("", data);
 
             expect(binding.serialize()).to.deep.equal(data);
         });
@@ -38,7 +39,7 @@ describe("CommandLineBindingModel", () => {
         it("Should serialize binding with customProps", () => {
             const data    = {
                 valueFrom: {
-                    "class": "Expression",
+                    "class": <ExpressionClass> "Expression",
                     engine: "#cwl-js-engine",
                     script: "---"
                 },
@@ -50,6 +51,6 @@ describe("CommandLineBindingModel", () => {
             const binding = new CommandLineBindingModel("", <CommandLineBinding>data);
 
             expect(binding.serialize()).to.deep.equal(data);
-        })
+        });
     })
 });

--- a/src/models/d2sb/CommandLineBindingModel.spec.ts
+++ b/src/models/d2sb/CommandLineBindingModel.spec.ts
@@ -1,5 +1,6 @@
 import {expect} from "chai";
 import {CommandLineBindingModel} from "./CommandLineBindingModel";
+import {CommandLineBinding} from "../../mappings/d2sb/CommandLineBinding";
 
 describe("CommandLineBindingModel", () => {
     describe("updateValidity", () => {
@@ -19,4 +20,36 @@ describe("CommandLineBindingModel", () => {
             expect(binding.validation.errors[0].message).to.contain("SyntaxError");
         });
     });
+
+    describe("serialize", () => {
+        it("Should serialize binding with valueFrom", () => {
+            const data    = {
+                valueFrom: {
+                    "class": "Expression",
+                    engine: "#cwl-js-engine",
+                    script: "---"
+                }
+            };
+            const binding = new CommandLineBindingModel("", <CommandLineBinding>data);
+
+            expect(binding.serialize()).to.deep.equal(data);
+        });
+
+        it("Should serialize binding with customProps", () => {
+            const data    = {
+                valueFrom: {
+                    "class": "Expression",
+                    engine: "#cwl-js-engine",
+                    script: "---"
+                },
+                "pref:custom": {
+                    complex: "value",
+                    arr: [2, 3, 4, 5]
+                }
+            };
+            const binding = new CommandLineBindingModel("", <CommandLineBinding>data);
+
+            expect(binding.serialize()).to.deep.equal(data);
+        })
+    })
 });

--- a/src/models/d2sb/CommandLineBindingModel.ts
+++ b/src/models/d2sb/CommandLineBindingModel.ts
@@ -11,7 +11,7 @@ export class CommandLineBindingModel extends ValidationBase implements Serializa
     public itemSeparator: string;
     public valueFrom: ExpressionModel;
 
-    private customProps: any = {};
+    public customProps: any = {};
     private serializedKeys: string[] = ["position", "prefix", "separate", "itemSeparator", "valueFrom"];
 
     constructor(loc: string, binding: CommandLineBinding) {

--- a/src/models/d2sb/CommandLineToolModel.spec.ts
+++ b/src/models/d2sb/CommandLineToolModel.spec.ts
@@ -74,7 +74,7 @@ describe("CommandLineToolModel d2sb", () => {
 
         it("Should evaluate BWA mem tool: General test of command line generation", () => {
             //noinspection TypeScriptUnresolvedVariable
-            let tool = new CommandLineToolModel(BWAMemTool.default);
+            let tool = new CommandLineToolModel("", BWAMemTool.default);
             //noinspection TypeScriptUnresolvedVariable
             tool.setJob(BWAMemJob.default);
 
@@ -83,7 +83,7 @@ describe("CommandLineToolModel d2sb", () => {
 
         it("Should evaluate BWM mem tool: Test nested prefixes with arrays", () => {
             //noinspection TypeScriptUnresolvedVariable
-            let tool = new CommandLineToolModel(BindingTestTool.default);
+            let tool = new CommandLineToolModel("", BindingTestTool.default);
             //noinspection TypeScriptUnresolvedVariable
             tool.setJob(BWAMemJob.default);
 
@@ -201,7 +201,7 @@ describe("CommandLineToolModel d2sb", () => {
             expr.evaluate();
 
             expect(tool.validation.errors).to.not.be.empty;
-            expect(tool.validation.errors[0].loc).to.equal("baseCommand[0]");
+            expect(tool.validation.errors[0].loc).to.equal("document.baseCommand[0]");
             expect(tool.validation.errors[0].message).to.contain("SyntaxError");
 
             const expr2 = new ExpressionModel("", {
@@ -215,10 +215,10 @@ describe("CommandLineToolModel d2sb", () => {
             expr2.evaluate();
 
             expect(tool.validation.warnings).to.not.be.empty;
-            expect(tool.validation.warnings[0].loc).to.equal("baseCommand[1]", "location of warning");
+            expect(tool.validation.warnings[0].loc).to.equal("document.baseCommand[1]", "location of warning");
             expect(tool.validation.warnings[0].message).to.contain("ReferenceError", "value of warning");
 
-            expect(tool.validation.errors[0].loc).to.equal("baseCommand[0]", "location of error after setting warning");
+            expect(tool.validation.errors[0].loc).to.equal("document.baseCommand[0]", "location of error after setting warning");
             expect(tool.validation.errors[0].message).to.contain("SyntaxError", "value of error after setting warning");
         });
 

--- a/src/models/d2sb/CommandLineToolModel.ts
+++ b/src/models/d2sb/CommandLineToolModel.ts
@@ -20,7 +20,7 @@ export class CommandLineToolModel extends ValidationBase implements CommandLineR
     inputs: Array<CommandInputParameterModel>   = [];
     outputs: Array<CommandOutputParameterModel> = [];
     readonly 'class': string;
-    baseCommand: Array<ExpressionModel> = [];
+    baseCommand: Array<ExpressionModel>         = [];
 
     arguments: Array<CommandArgumentModel> = [];
 
@@ -64,7 +64,8 @@ export class CommandLineToolModel extends ValidationBase implements CommandLineR
             this.updateValidity(err);
         });
 
-        return argument;    }
+        return argument;
+    }
 
     public removeArgument(arg: CommandArgumentModel | number) {
         if (typeof arg === "number") {
@@ -193,6 +194,7 @@ export class CommandLineToolModel extends ValidationBase implements CommandLineR
 
         base.class       = "CommandLineTool";
         base.baseCommand = this.baseCommand.map(cmd => cmd.serialize());
+        base.inputs      = this.inputs.map(input => input.serialize());
 
         base = Object.assign({}, base, this.customProps);
 
@@ -200,7 +202,7 @@ export class CommandLineToolModel extends ValidationBase implements CommandLineR
     }
 
     deserialize(attr: CommandLineTool): void {
-        const serializedAttr = ["baseCommand", "class", "id"];
+        const serializedAttr = ["baseCommand", "class", "id", "inputs"];
 
         this.id = attr.id;
 
@@ -213,7 +215,7 @@ export class CommandLineToolModel extends ValidationBase implements CommandLineR
 
         if (attr.arguments) {
             attr.arguments.forEach((arg, index) => {
-                this.addArgument(new CommandArgumentModel(`${this.loc}.arguments[${index}]`, arg) )
+                this.addArgument(new CommandArgumentModel(`${this.loc}.arguments[${index}]`, arg))
             });
         }
 

--- a/src/models/d2sb/CommandOutputParameterModel.ts
+++ b/src/models/d2sb/CommandOutputParameterModel.ts
@@ -1,20 +1,68 @@
 import {CommandOutputParameter} from "../../mappings/d2sb/CommandOutputParameter";
-import {Datatype} from "../../mappings/d2sb/Datatype";
-import {CommandOutputSchema} from "../../mappings/d2sb/CommandOutputSchema";
 import {CommandOutputBinding} from "../../mappings/d2sb/CommandOutputBinding";
+import {Serializable} from "../interfaces/Serializable";
+import {TypeResolution, TypeResolver, PrimitiveType} from "../helpers/TypeResolver";
+import {ValidationBase} from "../helpers/validation";
+import {CommandOutputRecordField} from "../../mappings/v1.0/CommandOutputRecordField";
+import {ParameterTypeModel, PrimitiveParameterType} from "./ParameterTypeModel";
 
-export class CommandOutputParameterModel implements CommandOutputParameter {
+export class CommandOutputParameterModel extends ValidationBase implements Serializable<CommandOutputParameter> {
     id: string;
-    type: Datatype | CommandOutputSchema | string | Array<Datatype | CommandOutputSchema | string>;
+    _type: ParameterTypeModel;
     outputBinding: CommandOutputBinding;
     label: string;
     description: string;
 
-    constructor(attr: CommandOutputParameter) {
+    get isRequired(): boolean {
+        return this._type.isRequired;
+    }
+
+    set isRequired(r: boolean) {
+        this._type.isRequired = r;
+    }
+
+    get type(): PrimitiveParameterType {
+        return this._type.type;
+    }
+
+    set type(t: PrimitiveParameterType) {
+        this._type.setType(t);
+    }
+
+    get items(): PrimitiveParameterType {
+        return this._type.items;
+    }
+
+    set items(t: PrimitiveParameterType) {
+        this._type.type = "array";
+        this._type.items = t;
+    }
+
+    get fields(): Array<CommandOutputRecordField> {
+        return <Array<CommandOutputRecordField>> this._type.fields;
+    }
+
+    constructor(loc: string, attr: CommandOutputParameter) {
+        super(loc);
+        this.deserialize(attr);
+    }
+
+    serialize(): CommandOutputParameter {
+        const output: CommandOutputParameter = <CommandOutputParameter>{};
+
+        output.id = this.id;
+
+        if (this.outputBinding) output.outputBinding = this.outputBinding;
+
+        return output;
+    }
+
+    deserialize(attr: CommandOutputParameter): void {
         this.id            = attr.id;
         this.outputBinding = attr.outputBinding;
-        this.type          = attr.type;
+        this._type         = TypeResolver.resolveType(attr.type);
         this.label         = attr.label;
         this.description   = attr.description;
     }
+
 }

--- a/src/models/d2sb/CommandOutputParameterModel.ts
+++ b/src/models/d2sb/CommandOutputParameterModel.ts
@@ -5,7 +5,7 @@ import {ValidationBase} from "../helpers/validation";
 import {OutputParameterTypeModel} from "./OutputParameterTypeModel";
 
 export class CommandOutputParameterModel extends ValidationBase implements Serializable<CommandOutputParameter> {
-    customProps: any;
+    customProps: any = {};
 
     id: string;
     type: OutputParameterTypeModel;
@@ -14,7 +14,7 @@ export class CommandOutputParameterModel extends ValidationBase implements Seria
     description: string;
 
 
-    constructor(loc: string, output: CommandOutputParameter) {
+    constructor(loc: string, output?: CommandOutputParameter) {
         super(loc);
         this.deserialize(output);
     }

--- a/src/models/d2sb/CommandOutputParameterModel.ts
+++ b/src/models/d2sb/CommandOutputParameterModel.ts
@@ -1,68 +1,54 @@
 import {CommandOutputParameter} from "../../mappings/d2sb/CommandOutputParameter";
 import {CommandOutputBinding} from "../../mappings/d2sb/CommandOutputBinding";
 import {Serializable} from "../interfaces/Serializable";
-import {TypeResolution, TypeResolver, PrimitiveType} from "../helpers/TypeResolver";
 import {ValidationBase} from "../helpers/validation";
-import {CommandOutputRecordField} from "../../mappings/v1.0/CommandOutputRecordField";
-import {ParameterTypeModel, PrimitiveParameterType} from "./ParameterTypeModel";
+import {OutputParameterTypeModel} from "./OutputParameterTypeModel";
 
 export class CommandOutputParameterModel extends ValidationBase implements Serializable<CommandOutputParameter> {
+    customProps: any;
+
     id: string;
-    _type: ParameterTypeModel;
+    type: OutputParameterTypeModel;
     outputBinding: CommandOutputBinding;
     label: string;
     description: string;
 
-    get isRequired(): boolean {
-        return this._type.isRequired;
-    }
 
-    set isRequired(r: boolean) {
-        this._type.isRequired = r;
-    }
-
-    get type(): PrimitiveParameterType {
-        return this._type.type;
-    }
-
-    set type(t: PrimitiveParameterType) {
-        this._type.setType(t);
-    }
-
-    get items(): PrimitiveParameterType {
-        return this._type.items;
-    }
-
-    set items(t: PrimitiveParameterType) {
-        this._type.type = "array";
-        this._type.items = t;
-    }
-
-    get fields(): Array<CommandOutputRecordField> {
-        return <Array<CommandOutputRecordField>> this._type.fields;
-    }
-
-    constructor(loc: string, attr: CommandOutputParameter) {
+    constructor(loc: string, output: CommandOutputParameter) {
         super(loc);
-        this.deserialize(attr);
+        this.deserialize(output);
     }
 
     serialize(): CommandOutputParameter {
-        const output: CommandOutputParameter = <CommandOutputParameter>{};
+        let base: any = {};
+        base = Object.assign({}, base, this.customProps);
 
-        output.id = this.id;
+        base.type = this.type.serialize();
 
-        if (this.outputBinding) output.outputBinding = this.outputBinding;
+        if (this.label) base.label = this.label;
+        if (this.description) base.description = this.description;
+        if (this.outputBinding) base.outputBinding = this.outputBinding;
 
-        return output;
+        base.id = this.id;
+
+        return base;
     }
 
     deserialize(attr: CommandOutputParameter): void {
+        const serializedAttr = ["id", "label", "description", "outputBinding", "type"];
+
         this.id            = attr.id;
         this.outputBinding = attr.outputBinding;
-        this._type         = TypeResolver.resolveType(attr.type);
         this.label         = attr.label;
         this.description   = attr.description;
+
+        this.type = new OutputParameterTypeModel(attr.type, `${this.loc}.type`);
+
+        Object.keys(attr).forEach(key => {
+            if (serializedAttr.indexOf(key) === -1) {
+                this.customProps[key] = attr[key];
+            }
+        });
     }
 
 }

--- a/src/models/d2sb/ExpressionModel.spec.ts
+++ b/src/models/d2sb/ExpressionModel.spec.ts
@@ -1,6 +1,7 @@
 import {expect} from "chai";
 import {ExpressionModel} from "./ExpressionModel";
 import {Expression} from "../../mappings/d2sb/Expression";
+import {ExpressionClass} from "../../mappings/d2sb/Expression";
 
 describe("ExpressionModel d2sb", () => {
 
@@ -107,7 +108,7 @@ describe("ExpressionModel d2sb", () => {
 
         it("Should serialize an expression with custom properties", () => {
             const data = {
-                "class": "Expression",
+                "class": <ExpressionClass> "Expression",
                 engine: "#cwl-js-engine",
                 script: "{ return 3 + 3 }",
                 "pref:custom": "some value"

--- a/src/models/d2sb/ExpressionModel.spec.ts
+++ b/src/models/d2sb/ExpressionModel.spec.ts
@@ -88,6 +88,34 @@ describe("ExpressionModel d2sb", () => {
         });
     });
 
+    describe("serialize", () => {
+        it("Should serialize a simple string", () => {
+            const data = "simple string";
+            const expr = new ExpressionModel("", data);
+            expect(expr.serialize()).to.equal(data);
+        });
+
+        it("Should serialize an expression", () => {
+            const data = {
+                "class": "Expression",
+                engine: "#cwl-js-engine",
+                script: "{ return 3 + 3 }"
+            };
+            const expr = new ExpressionModel("", <Expression> data);
+            expect(expr.serialize()).to.equal(data);
+        });
+
+        it("Should serialize an expression with custom properties", () => {
+            const data = {
+                "class": "Expression",
+                engine: "#cwl-js-engine",
+                script: "{ return 3 + 3 }",
+                "pref:custom": "some value"
+            };
+            const expr = new ExpressionModel("", <Expression> data);
+            expect(expr.serialize()).to.equal(data);
+        });
+    });
 
     //
     // describe("getExpressionScript", () => {

--- a/src/models/d2sb/ExpressionModel.ts
+++ b/src/models/d2sb/ExpressionModel.ts
@@ -4,6 +4,7 @@ import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
 import {ValidationBase, Validation} from "../helpers/validation";
 
 export class ExpressionModel extends ValidationBase implements Serializable<string | Expression> {
+    customProps: any = {};
 
     validate(): Validation {
         return this.validation;

--- a/src/models/d2sb/InputParameterTypeModel.ts
+++ b/src/models/d2sb/InputParameterTypeModel.ts
@@ -1,0 +1,64 @@
+import {ParameterTypeModel} from "./ParameterTypeModel";
+import {CommandInputParameterModel} from "./CommandInputParameterModel";
+import {Validation} from "../helpers/validation/Validation";
+import {CommandInputParameter} from "../../mappings/d2sb/CommandInputParameter";
+import {CommandInputRecordField} from "../../mappings/d2sb/CommandInputRecordField";
+
+export class InputParameterTypeModel extends ParameterTypeModel {
+
+    constructor(attr: any, loc: string) {
+        super(loc, attr);
+
+        if (this.fields) {
+            this.fields = this.fields.map((field, index) => {
+                const f = new CommandInputParameterModel(`${this.loc}.fields[${index}]`, field);
+                f.setValidationCallback((err: Validation) => {this.updateValidity(err)});
+                return f;
+            });
+        }
+    }
+
+    public addField(field: CommandInputParameterModel | CommandInputParameter | CommandInputRecordField): void {
+        if (this.type !== "record" && this.items !== "record") {
+            throw(`Fields can only be added to type or items record: type is ${this.type}, items is ${this.items}.`);
+        } else {
+            const duplicate = this.fields.filter(val => {
+                return val.id === (<CommandInputRecordField> field).name
+                    || val.id === (<CommandInputParameter> field).id;
+            });
+            if (duplicate.length > 0) {
+                throw(`Field with name "${duplicate[0].id}" already exists`);
+            }
+
+            if (field instanceof CommandInputParameterModel) {
+                field.loc = `${this.loc}.fields[${this.fields.length}]`;
+                field.setValidationCallback((err: Validation) => {this.updateValidity(err)});
+
+                this.fields.push(field);
+            } else {
+                const f = new CommandInputParameterModel(`${this.loc}.fields[${this.fields.length}]`, <CommandInputRecordField>field);
+                f.setValidationCallback((err: Validation) => {this.updateValidity(err)});
+
+                this.fields.push(f);
+            }
+        }
+    }
+
+    public removeField(field: CommandInputParameterModel | string) {
+        let found;
+
+        if (typeof field === "string") {
+            found = this.fields.filter(val => val.id === field)[0];
+        } else {
+            found = field;
+        }
+
+        const index = this.fields.indexOf(found);
+        if (index < 0) {
+            throw(`Field ${field} does not exist on input`);
+        }
+
+        //noinspection TypeScriptValidateTypes
+        this.fields.splice(index, 1);
+    }
+}

--- a/src/models/d2sb/InputParameterTypeModel.ts
+++ b/src/models/d2sb/InputParameterTypeModel.ts
@@ -61,4 +61,19 @@ export class InputParameterTypeModel extends ParameterTypeModel {
         //noinspection TypeScriptValidateTypes
         this.fields.splice(index, 1);
     }
+
+    serialize(): any {
+        const base = super.serialize();
+
+        if (this.fields) {
+            if (Array.isArray(base)) {
+                const t = base[0].fields ? base[0] : (base[1].fields ? base[1] : null);
+                if (t) t.fields = this.fields.map(field => field.serialize());
+            } else if (base.fields) {
+                base.fields = this.fields.map(field => field.serialize());
+            }
+        }
+
+        return base;
+    }
 }

--- a/src/models/d2sb/InputParameterTypeModel.ts
+++ b/src/models/d2sb/InputParameterTypeModel.ts
@@ -5,12 +5,14 @@ import {CommandInputParameter} from "../../mappings/d2sb/CommandInputParameter";
 import {CommandInputRecordField} from "../../mappings/d2sb/CommandInputRecordField";
 
 export class InputParameterTypeModel extends ParameterTypeModel {
+    public fields: Array<CommandInputParameterModel>;
 
     constructor(attr: any, loc: string) {
         super(loc, attr);
 
         if (this.fields) {
             this.fields = this.fields.map((field, index) => {
+                //noinspection TypeScriptValidateTypes
                 const f = new CommandInputParameterModel(`${this.loc}.fields[${index}]`, field);
                 f.setValidationCallback((err: Validation) => {this.updateValidity(err)});
                 return f;

--- a/src/models/d2sb/OutputParameterTypeModel.ts
+++ b/src/models/d2sb/OutputParameterTypeModel.ts
@@ -1,0 +1,8 @@
+import {ParameterTypeModel} from "./ParameterTypeModel";
+import {CommandOutputParameterType} from "../../mappings/d2sb/CommandOutputParameter";
+
+export class OutputParameterTypeModel extends ParameterTypeModel {
+    constructor(attr: CommandOutputParameterType, loc: string) {
+        super(loc, attr);
+    }
+}

--- a/src/models/d2sb/ParameterTypeModel.ts
+++ b/src/models/d2sb/ParameterTypeModel.ts
@@ -41,10 +41,12 @@ export abstract class ParameterTypeModel extends ValidationBase implements Seria
             case "enum":
                 this._items = null;
                 this.fields = null;
+                this.symbols = this.symbols || [];
                 break;
             case "record":
                 this._items = null;
                 this.symbols = null;
+                this.fields = this.fields || [];
                 break;
         }
     }

--- a/src/models/d2sb/ParameterTypeModel.ts
+++ b/src/models/d2sb/ParameterTypeModel.ts
@@ -1,0 +1,90 @@
+import {CommandOutputRecordField} from "../../mappings/v1.0/CommandOutputRecordField";
+import {CommandInputRecordField} from "../../mappings/d2sb/CommandInputRecordField";
+import {Serializable} from "../interfaces/Serializable";
+import {TypeResolver, TypeResolution} from "../helpers/TypeResolver";
+import {CommandLineBinding} from "../../mappings/d2sb/CommandLineBinding";
+import {ValidationBase} from "../helpers/validation/ValidationBase";
+import {CommandOutputParameterType} from "../../mappings/d2sb/CommandOutputParameter";
+import {CommandInputParameterType} from "../../mappings/d2sb/CommandInputParameter";
+
+export type PrimitiveParameterType = "array" | "enum" | "record" | "File" | "string" | "int" | "float" | "null" | "boolean" | "long" | "double" | "bytes";
+
+export abstract class ParameterTypeModel extends ValidationBase implements Serializable<any>, TypeResolution {
+    private _items: PrimitiveParameterType;
+
+    get items(): PrimitiveParameterType {
+        return this._items;
+    }
+
+    set items(t: PrimitiveParameterType) {
+        if (this._type !== "array") {
+            throw("ParameterTypeModel: Items can only be set to inputs type Array");
+        } else {
+            this._items = t;
+        }
+    }
+
+    private _type: PrimitiveParameterType;
+
+    get type(): PrimitiveParameterType {
+        return this._type;
+    }
+
+    set type(t: PrimitiveParameterType) {
+        this._type = t;
+
+        switch (t) {
+            case "array":
+                this.symbols = null;
+                this.fields  = null;
+                break;
+            case "enum":
+                this._items = null;
+                this.fields = null;
+                break;
+            case "record":
+                this._items = null;
+                this.symbols = null;
+                break;
+        }
+    }
+
+    isNullable: boolean;
+    typeBinding: CommandLineBinding;
+    fields: Array<CommandInputRecordField>|Array<CommandOutputRecordField>;
+    symbols: string[];
+    name: string;
+
+    constructor(loc: string, type: CommandInputParameterType | CommandOutputParameterType) {
+        super(loc);
+        this.deserialize(type);
+    }
+
+    serialize(): any {
+        return TypeResolver.serializeType(this);
+    }
+
+    deserialize(attr: any ): void {
+        TypeResolver.resolveType(attr, this);
+
+    }
+
+    setType(t: PrimitiveParameterType): void {
+        this._type = t;
+
+        switch (t) {
+            case "array":
+                this.symbols = null;
+                this.fields  = null;
+                break;
+            case "enum":
+                this._items = null;
+                this.fields = null;
+                break;
+            case "record":
+                this._items = null;
+                this.symbols = null;
+                break;
+        }
+    }
+}

--- a/src/models/helpers/CommandLinePart.ts
+++ b/src/models/helpers/CommandLinePart.ts
@@ -1,5 +1,5 @@
 import {MSDSortable} from "./MSDSort";
-export type CommandType = "baseCommand" | "input" | "argument" | "stdin" | "stdout"
+export type CommandType = "baseCommand" | "input" | "argument" | "stdin" | "stdout" | "error" | "warning"
 
 export class CommandLinePart implements MSDSortable {
     public value: string;
@@ -14,10 +14,10 @@ export class CommandLinePart implements MSDSortable {
         this.type = type;
 
         if (Array.isArray(sortingKey)) {
-            this.sortingKey = sortingKey;
+            this.sortingKey = <Array<string|number>> sortingKey;
         } else {
             this.sortingKey = [];
-            this.sortingKey.push(sortingKey);
+            this.sortingKey.push(<string|number>sortingKey);
         }
     }
 

--- a/src/models/helpers/TypeResolver.spec.ts
+++ b/src/models/helpers/TypeResolver.spec.ts
@@ -7,7 +7,7 @@ describe("TypeResolver", () => {
             let resolved = TypeResolver.resolveType("string");
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("string");
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
             expect(resolved.items).to.be.null;
         });
 
@@ -16,7 +16,7 @@ describe("TypeResolver", () => {
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("array");
             expect(resolved.items).to.be.equal("string");
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should resolve type shorthand for optional single item", () => {
@@ -24,7 +24,7 @@ describe("TypeResolver", () => {
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("string");
             expect(resolved.items).to.be.null;
-            expect(resolved.isRequired).to.be.false;
+            expect(resolved.isNullable).to.be.true;
         });
 
         it("Should resolve type shorthand for optional array", () => {
@@ -32,7 +32,7 @@ describe("TypeResolver", () => {
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("array");
             expect(resolved.items).to.be.equal("string");
-            expect(resolved.isRequired).to.be.false;
+            expect(resolved.isNullable).to.be.true;
         });
 
         it("Should resolve optional union type of primitive type", () => {
@@ -40,7 +40,7 @@ describe("TypeResolver", () => {
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("string");
             expect(resolved.items).to.be.null;
-            expect(resolved.isRequired).to.be.false;
+            expect(resolved.isNullable).to.be.true;
         });
 
         it("Should resolve optional union type of primitive type", () => {
@@ -48,14 +48,14 @@ describe("TypeResolver", () => {
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("string");
             expect(resolved.items).to.be.null;
-            expect(resolved.isRequired).to.be.false;
+            expect(resolved.isNullable).to.be.true;
         });
 
         it("Should resolve required primitive type defined as union", () => {
             let resolved = TypeResolver.resolveType(["string"]);
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("string");
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
             expect(resolved.items).to.be.null;
         });
 
@@ -64,7 +64,7 @@ describe("TypeResolver", () => {
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("array");
             expect(resolved.items).to.be.equal("string");
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should resolve complex record type", () => {
@@ -76,7 +76,7 @@ describe("TypeResolver", () => {
             expect(resolved.type).to.be.equal("record");
             expect(resolved.items).to.be.null;
             expect(resolved.fields).to.have.lengthOf(1);
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should resolve complex enum type", () => {
@@ -86,7 +86,7 @@ describe("TypeResolver", () => {
             expect(resolved.symbols).to.have.lengthOf(2);
             expect(resolved.items).to.be.null;
             expect(resolved.fields).to.be.null;
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should resolve complex array of enum type", () => {
@@ -99,7 +99,7 @@ describe("TypeResolver", () => {
             expect(resolved.symbols).to.have.lengthOf(2);
             expect(resolved.items).to.equal("enum");
             expect(resolved.fields).to.be.null;
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should resolve complex array of record type", () => {
@@ -120,7 +120,7 @@ describe("TypeResolver", () => {
             expect(resolved.fields).to.have.lengthOf(1);
             expect(resolved.items).to.equal("record");
             expect(resolved.symbols).to.be.null;
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should resolve optional complex record type defined as union", () => {
@@ -132,7 +132,7 @@ describe("TypeResolver", () => {
             expect(resolved.type).to.be.equal("record");
             expect(resolved.items).to.be.null;
             expect(resolved.fields).to.have.length(1);
-            expect(resolved.isRequired).to.be.false;
+            expect(resolved.isNullable).to.be.true;
         });
 
         it("Should resolve required complex record type defined as union", () => {
@@ -144,7 +144,7 @@ describe("TypeResolver", () => {
             expect(resolved.type).to.be.equal("record");
             expect(resolved.items).to.be.null;
             expect(resolved.fields).to.have.length(1);
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should resolve array of records type", () => {
@@ -156,7 +156,7 @@ describe("TypeResolver", () => {
             expect(resolved.type).to.be.equal("record");
             expect(resolved.items).to.be.null;
             expect(resolved.fields).to.have.length(1);
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.isNullable).to.be.false;
         });
 
         it("Should throw an exception for an unexpected complex type", () => {
@@ -167,7 +167,7 @@ describe("TypeResolver", () => {
 
         it("Should return optional input of no type for null", () => {
             let resolved = TypeResolver.resolveType(null);
-            expect(resolved.isRequired).to.be.false;
+            expect(resolved.isNullable).to.be.true;
             expect(resolved.type).to.be.null;
         });
 
@@ -188,10 +188,10 @@ describe("TypeResolver", () => {
             expect(resolved).to.not.be.undefined;
             expect(resolved.type).to.be.equal("array");
             expect(resolved.items).to.equal("string");
-            expect(resolved.itemsBinding).to.not.be.null;
-            expect(resolved.itemsBinding).to.have.property('prefix');
-            expect(resolved.itemsBinding.prefix).to.equal("-p");
-            expect(resolved.isRequired).to.be.true;
+            expect(resolved.typeBinding).to.not.be.null;
+            expect(resolved.typeBinding).to.have.property('prefix');
+            expect(resolved.typeBinding.prefix).to.equal("-p");
+            expect(resolved.isNullable).to.be.false;
         })
     });
 
@@ -209,6 +209,137 @@ describe("TypeResolver", () => {
             expect(TypeResolver.doesTypeMatch("double", 323), "double should be a number").to.be.true;
             expect(TypeResolver.doesTypeMatch("int", 323), "int should be a number").to.be.true;
             expect(TypeResolver.doesTypeMatch("int", "hello"), "int shouldn't be a string").to.be.false;
+        });
+    });
+
+    describe("serializeType", () => {
+        it("should resolve a primitive type that is required", () => {
+            const resolved   = TypeResolver.resolveType(["string"]);
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal(["string"]);
+        });
+
+        it("should resolve a primitive type that is not required", () => {
+            const resolved   = TypeResolver.resolveType(["null", "string"]);
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal(["null", "string"]);
+        });
+
+        it("should resolve a complex array type that is required", () => {
+            const resolved   = TypeResolver.resolveType({type: "array", items: "File"});
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal([{type: "array", items: "File"}]);
+        });
+
+        it("should resolve a complex array type that is not required", () => {
+            const resolved   = TypeResolver.resolveType(["null", {type: "array", items: "File"}]);
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal(["null", {type: "array", items: "File"}]);
+        });
+
+        it("should resolve complex enum type that is required", () => {
+            const resolved   = TypeResolver.resolveType({
+                type: "enum",
+                name: "enum",
+                symbols: ["one", "two"]
+            });
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal([{
+                type: "enum",
+                name: "enum",
+                symbols: ["one", "two"]
+            }]);
+        });
+
+        it("should resolve complex enum type that is not required", () => {
+            const resolved   = TypeResolver.resolveType(["null", {
+                type: "enum",
+                name: "enum",
+                symbols: ["one", "two"]
+            }]);
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal(["null", {
+                type: "enum",
+                name: "enum",
+                symbols: ["one", "two"]
+            }]);
+        });
+
+        it("should resolve complex record type that is required", () => {
+            const resolved   = TypeResolver.resolveType({
+                type: "record",
+                name: "rec",
+                fields: [
+                    {id: "f1", type: "string"},
+                    {id: "f2", type: "File"}
+                ]
+            });
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal([{
+                type: "record",
+                name: "rec",
+                fields: [
+                    {id: "f1", type: "string"},
+                    {id: "f2", type: "File"}
+                ]
+            }]);
+        });
+
+        it("should resolve complex record type that is not required", () => {
+            const resolved   = TypeResolver.resolveType(["null", {
+                type: "record",
+                name: "rec",
+                fields: [
+                    {id: "f1", type: "string"},
+                    {id: "f2", type: "File"}
+                ]
+            }]);
+            const serialized = TypeResolver.serializeType(resolved);
+
+            expect(serialized).to.deep.equal(["null", {
+                type: "record",
+                name: "rec",
+                fields: [
+                    {id: "f1", type: "string"},
+                    {id: "f2", type: "File"}
+                ]
+            }]);
+        });
+
+        it("should resolve shorthand for array", () => {
+            const resolved   = TypeResolver.resolveType("string[]");
+            const serializedV1 = TypeResolver.serializeType(resolved, "v1.0");
+            const serializedD2 = TypeResolver.serializeType(resolved);
+
+            expect(serializedV1).to.deep.equal("string[]");
+            expect(serializedD2).to.deep.equal([{type: "array", items: "string"}]);
+        });
+
+        it("should resolve shorthand for primitive that is not required", () => {
+            const resolved   = TypeResolver.resolveType("string?");
+            const serializedV1 = TypeResolver.serializeType(resolved, "v1.0");
+            const serializedD2 = TypeResolver.serializeType(resolved);
+
+            expect(serializedV1).to.deep.equal("string?");
+            expect(serializedD2).to.deep.equal(["null", "string"]);
+        });
+
+        it("should resolve shorthand for array that is not required", () => {
+            it("should resolve shorthand for array", () => {
+                const resolved   = TypeResolver.resolveType("string[]?");
+                const serializedV1 = TypeResolver.serializeType(resolved, "v1.0");
+                const serializedD2 = TypeResolver.serializeType(resolved);
+
+                expect(serializedV1).to.deep.equal("string[]?");
+                expect(serializedD2).to.deep.equal(["null", {type: "array", items: "string"}]);
+            });
         });
     });
 });

--- a/src/models/helpers/TypeResolver.ts
+++ b/src/models/helpers/TypeResolver.ts
@@ -1,14 +1,14 @@
-import {CommandLineBinding} from "../../mappings/draft-4/CommandLineBinding";
+import {CommandLineBinding} from "../../mappings/d2sb/CommandLineBinding";
 import {CommandInputRecordField} from "../../mappings/d2sb/CommandInputRecordField";
-import {CommandOutputRecordField} from "../../mappings/v1.0/CommandOutputRecordField";
 import {CWLVersion} from "../../mappings/v1.0/CWLVersion";
+import {CommandOutputSchema} from "../../mappings/d2sb/CommandOutputSchema";
 
 export type PrimitiveType = "array" | "enum" | "record" | "File" | "string" | "int" | "float" | "null" | "boolean" | "long" | "double" | "bytes";
 
 export interface TypeResolution {
     type: PrimitiveType;
     items: PrimitiveType;
-    fields: Array<CommandInputRecordField>|Array<CommandOutputRecordField>;
+    fields: Array<CommandInputRecordField>|Array<CommandOutputSchema>;
     symbols: string[]
     isNullable: boolean;
     typeBinding: CommandLineBinding;

--- a/src/models/helpers/TypeResolver.ts
+++ b/src/models/helpers/TypeResolver.ts
@@ -1,9 +1,6 @@
 import {CommandLineBinding} from "../../mappings/draft-4/CommandLineBinding";
 import {CommandInputRecordField} from "../../mappings/d2sb/CommandInputRecordField";
 import {CommandOutputRecordField} from "../../mappings/v1.0/CommandOutputRecordField";
-import {CommandInputArraySchema} from "../../mappings/d2sb/CommandInputSchema";
-import {CommandInputRecordSchema} from "../../mappings/d2sb/CommandInputSchema";
-import {CommandInputEnumSchema} from "../../mappings/d2sb/CommandInputSchema";
 import {CWLVersion} from "../../mappings/v1.0/CWLVersion";
 
 export type PrimitiveType = "array" | "enum" | "record" | "File" | "string" | "int" | "float" | "null" | "boolean" | "long" | "double" | "bytes";
@@ -31,10 +28,14 @@ export class TypeResolver {
                 name: null
             };
 
+
         if (type === null || type === undefined) {
             result.isNullable = true;
             return result;
         }
+
+        // clone type object because it will be sliced and modified later
+        type = JSON.parse(JSON.stringify(type));
 
         if (typeof type === 'string') {
             let matches = /(\w+)([\[\]?]+)/g.exec(<string> type);

--- a/src/models/helpers/TypeResolver.ts
+++ b/src/models/helpers/TypeResolver.ts
@@ -1,13 +1,21 @@
 import {CommandLineBinding} from "../../mappings/draft-4/CommandLineBinding";
+import {CommandInputRecordField} from "../../mappings/d2sb/CommandInputRecordField";
+import {CommandOutputRecordField} from "../../mappings/v1.0/CommandOutputRecordField";
+import {CommandInputArraySchema} from "../../mappings/d2sb/CommandInputSchema";
+import {CommandInputRecordSchema} from "../../mappings/d2sb/CommandInputSchema";
+import {CommandInputEnumSchema} from "../../mappings/d2sb/CommandInputSchema";
+import {CWLVersion} from "../../mappings/v1.0/CWLVersion";
+
+export type PrimitiveType = "array" | "enum" | "record" | "File" | "string" | "int" | "float" | "null" | "boolean" | "long" | "double" | "bytes";
 
 export interface TypeResolution {
-    type: string;
-    items: string;
-    fields: any[];
-    symbols: string[];
-    isRequired: boolean;
-    itemsBinding: CommandLineBinding,
-    typeName: string;
+    type: PrimitiveType;
+    items: PrimitiveType;
+    fields: Array<CommandInputRecordField>|Array<CommandOutputRecordField>;
+    symbols: string[]
+    isNullable: boolean;
+    typeBinding: CommandLineBinding;
+    name: string;
 }
 
 export class TypeResolver {
@@ -18,13 +26,13 @@ export class TypeResolver {
                 items: null,
                 fields: null,
                 symbols: null,
-                isRequired: true,
-                itemsBinding: null,
-                typeName: null
+                isNullable: false,
+                typeBinding: null,
+                name: null
             };
 
         if (type === null || type === undefined) {
-            result.isRequired = false;
+            result.isNullable = true;
             return result;
         }
 
@@ -32,19 +40,19 @@ export class TypeResolver {
             let matches = /(\w+)([\[\]?]+)/g.exec(<string> type);
             if (matches) {
                 if (/\?/.test(matches[2])) {
-                    result.isRequired = false;
+                    result.isNullable = true;
                 }
 
                 if (/\[]/.test(matches[2])) {
                     result.type  = 'array';
-                    result.items = matches[1];
+                    result.items = <PrimitiveType> matches[1];
                 } else {
-                    result.type = matches[1];
+                    result.type = <PrimitiveType> matches[1];
                 }
 
                 return result;
             } else {
-                result.type = type;
+                result.type = <PrimitiveType> type;
                 return result;
             }
         } else if (Array.isArray(type)) {
@@ -52,7 +60,7 @@ export class TypeResolver {
             let nullIndex = (<Array<any>> type).indexOf('null');
 
             if (nullIndex > -1) {
-                result.isRequired = false;
+                result.isNullable = true;
                 type.splice(nullIndex, 1);
             }
 
@@ -80,7 +88,7 @@ export class TypeResolver {
                 }
                 switch (type.type) {
                     case "array":
-                        result.itemsBinding = type.inputBinding || null;
+                        result.typeBinding = type.inputBinding || null;
                         if (typeof type.items === 'string') {
                             // primitive types don't need to be reevaluated
                             result.items = type.items;
@@ -91,11 +99,11 @@ export class TypeResolver {
                         }
                     case "record":
                         result.fields = type.fields;
-                        result.typeName = type.name || null;
+                        result.name   = type.name || null;
                         return result;
                     case "enum":
                         result.symbols = type.symbols;
-                        result.typeName = type.name || null;
+                        result.name    = type.name || null;
                         return result;
                     case "string":
                     case "File":
@@ -118,7 +126,7 @@ export class TypeResolver {
         }
     }
 
-    public static doesTypeMatch(type: string, value: any) {
+    public static doesTypeMatch(type: PrimitiveType, value: any) {
 
         if (type) {
             switch (type) {
@@ -140,5 +148,54 @@ export class TypeResolver {
         }
 
         return true;
+    }
+
+    public static serializeType(type: TypeResolution, version?: CWLVersion): any {
+        let t;
+
+        switch (type.type) {
+            case "array":
+                if (version === "v1.0" && !type.typeBinding) {
+                    t = `${type.items}[]`;
+                } else {
+                    t = {
+                        type: "array",
+                        items: type.items
+                    };
+                    if (type.typeBinding) t.inputBinding = t;
+                }
+
+                break;
+
+            case "record":
+                t = {
+                    type: "record",
+                    fields: type.fields,
+                    name: type.name
+                };
+                if (type.typeBinding) t.inputBinding = t;
+                break;
+
+            case "enum":
+                t = {
+                    type: "enum",
+                    symbols: type.symbols,
+                    name: type.name
+                };
+
+                if (type.typeBinding) t.inputBinding = t;
+                break;
+
+            default:
+                t = type.type;
+        }
+
+        if (type.isNullable) {
+            t = version === "v1.0" ? `${t}?` : ["null", t];
+        } else if (version !== "v1.0") {
+            t = [t];
+        }
+
+        return t;
     }
 }

--- a/src/models/interfaces/Serializable.ts
+++ b/src/models/interfaces/Serializable.ts
@@ -1,4 +1,4 @@
 export interface Serializable<T> {
     serialize():T;
-    deserialize(T):void;
+    deserialize(attr: T):void;
 }

--- a/src/models/interfaces/Serializable.ts
+++ b/src/models/interfaces/Serializable.ts
@@ -1,4 +1,5 @@
 export interface Serializable<T> {
+    customProps: any;
     serialize():T;
     deserialize(attr: T):void;
 }

--- a/src/models/v1.0/CommandInputParameterModel.ts
+++ b/src/models/v1.0/CommandInputParameterModel.ts
@@ -10,16 +10,17 @@ import {
 } from "../../mappings/v1.0";
 import {CommandLineInjectable, Identifiable} from "../interfaces";
 import {CommandLinePart, ExpressionEvaluator, TypeResolver} from "../helpers";
+import {PrimitiveType} from "../helpers/TypeResolver";
 
 
 export class CommandInputParameterModel implements CommandInputParameter, CommandLineInjectable, Identifiable {
     id: string;
 
     isRequired: boolean = true;
-    items: string;
+    items: PrimitiveType;
     fields: Array<CommandInputParameterModel>;
     symbols: string[];
-    resolvedType: string;
+    resolvedType: PrimitiveType;
 
     type: CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string | Array<CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string>;
     inputBinding: CommandLineBinding;

--- a/src/models/v1.0/CommandInputParameterModel.ts
+++ b/src/models/v1.0/CommandInputParameterModel.ts
@@ -57,7 +57,7 @@ export class CommandInputParameterModel implements CommandInputParameter, Comman
         this.symbols = typeResolution.symbols;
         this.items   = typeResolution.items;
 
-        this.isRequired = typeResolution.isRequired;
+        this.isRequired = !typeResolution.isNullable;
     }
 
     getCommandPart(job?: any, value?: any, self?: any): CommandLinePart {


### PR DESCRIPTION
**ParameterTypeModel**
This PR contains implementation for abstract `ParameterTypeModel` and concrete `InputParameterTypeModel` and `OutputParameterTypeModel`

`ParameterTypeModel` implements the `TypeResolution` interface and encapsulates logic for change an input's or output's type property. It uses [getters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) and [setters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) as an API for manipulating type properties like `items`, `symbols`, and primitive type. The `ParameterTypeModel` implement manipulation of field properties.

Any schematically incorrect procedure (setting `items` on type `string`, for example) will throw an exception.

**Usage:**

```typescript
const input = new CommandInputParameterModel("", {
    id: "inp",
    type: {
        type: "array",
        items: "string"
    }
});

console.log(input.type.type); // logs "array"
console.log(input.type.items); // logs "string"

input.type.type = "record";

input.type.addField({
    name: "field",
    type: "string"
});

input.type.items = "string"; // will throw exception, type is not array
```

> **Important change:**  The `isRequired` has been moved from the input root and into the type property and renamed to `isNullable`. The new property is  carries the same semantic information, but is a negation of `isRequired`.  `isRequired` === `!isNullable`

**CommandLinePart errors and warnings**
There are two new types of `CommandLinePart`: `error` and `warning`. They are created when evaluated expressions to the command line result in errors or warnings, respectively. The implementation is messy and should be refactored.