### PR TITLE
fix(cwlts): Initialize base command as empty array instead of an arra…

### DIFF
--- a/src/models/d2sb/SBDraft2CommandLineToolModel.ts
+++ b/src/models/d2sb/SBDraft2CommandLineToolModel.ts
@@ -269,7 +269,7 @@ export class SBDraft2CommandLineToolModel extends CommandLineToolModel implement
         this.temporaryFailCodes = ensureArray(tool.temporaryFailCodes);
         this.permanentFailCodes = ensureArray(tool.permanentFailCodes);
 
-        tool.baseCommand        = tool.baseCommand || [''];
+        tool.baseCommand        = tool.baseCommand || [];
 
         // wrap to array
         tool.baseCommand = !Array.isArray(tool.baseCommand)


### PR DESCRIPTION
…y with an empty string in it