### PR TITLE
fix: too strict INHERIT_REGEX gets inheritMetadata expressionLib removed

### DIFF
--- a/src/models/v1.0/V1CommandLineToolModel.spec.ts
+++ b/src/models/v1.0/V1CommandLineToolModel.spec.ts
@@ -1516,6 +1516,24 @@ describe("V1CommandLineToolModel", () => {
             expect(serialized.requirements[0]).to.not.haveOwnProperty("expressionLib");
         });
 
+        it('should allow custom expression after inherit script', () => {
+           const expr = `
+               \${
+                   inheritMetadata(self, inputs.input)
+                   self[0].metadata.library_id = self[0].metadata.library_id + '_new'
+                   return self
+               }
+           `;
+           outputWithInherit.outputBinding.setInheritMetadataFrom("input");
+           outputWithInherit.outputBinding.outputEval = new V1ExpressionModel(expr);
+
+           const serialized = model.serialize();
+
+           expect(serialized.requirements).to.not.be.empty;
+           expect(serialized.requirements[0].class).to.equal("InlineJavascriptRequirement");
+           expect(serialized.requirements[0]).to.haveOwnProperty("expressionLib");
+        });
+
         it("should remove outputEval inherit script if inherit metadata is removed", () => {
             output.outputBinding.setInheritMetadataFrom("input");
             output.outputBinding.setInheritMetadataFrom(null);

--- a/src/models/v1.0/V1CommandOutputBindingModel.ts
+++ b/src/models/v1.0/V1CommandOutputBindingModel.ts
@@ -10,7 +10,7 @@ export class V1CommandOutputBindingModel extends CommandOutputBindingModel {
     public hasMetadata        = false;
     public hasInheritMetadata = true;
 
-    static INHERIT_REGEX = /\$\(inheritMetadata\(self, inputs.(.*?)\)\)/g;
+    static INHERIT_REGEX = /.*(?:\s*)inheritMetadata\((?:\s*)self(?:\s*),(?:\s*)inputs.(.*?)(?:\s*)\)(?:\s*).*/g;
     public inheritMetadataFrom: string;
 
     protected _glob: V1ExpressionModel;


### PR DESCRIPTION
It should allow something like this:

```
${
  inheritMetadata(self, inputs.input)
  self[0].metadata.library_id = self[0].metadata.library_id + '_new'
  return self
}
```