### PR TITLE
Expression evaluation new warning

### DIFF
--- a/src/models/generic/ExpressionModel.ts
+++ b/src/models/generic/ExpressionModel.ts
@@ -107,6 +107,17 @@ export abstract class ExpressionModel extends ValidationBase implements Serializ
                 let message = ex.message;
                 let code = ErrorCode.EXPR_SYNTAX;
 
+                if (ex.type === "warning" && ex.code === ErrorCode.EXPR_LINTER_WARNING) {
+                    rej({
+                        type: ex.type,
+                        code: ex.code,
+                        loc: this.loc,
+                        message: message,
+                        payload: ex.payload
+                    });
+                    return;
+                }
+
                 if (ex.message.startsWith("Uncaught DataCloneError")) {
                     message = "Error: Return value should have transferable data (fully JSON-serializable)";
                     code = ErrorCode.EXPR_NOT_JSON;

--- a/src/models/generic/ExpressionModel.ts
+++ b/src/models/generic/ExpressionModel.ts
@@ -134,7 +134,8 @@ export abstract class ExpressionModel extends ValidationBase implements Serializ
                         code = ErrorCode.EXPR_TYPE;
                     }
 
-                    rej(Object.assign({type: "warning", code}, err));
+                    const type = version === 'v1.0' ? "error" : "warning";
+                    rej(Object.assign({type, code}, err));
                 }
             });
         });

--- a/src/models/helpers/CommandLineParsers.ts
+++ b/src/models/helpers/CommandLineParsers.ts
@@ -4,6 +4,7 @@ import {CommandLinePrepare} from "./CommandLinePrepare";
 import {TypeResolver} from "./TypeResolver";
 import {V1CommandArgumentModel} from "../v1.0/V1CommandArgumentModel";
 import {V1ExpressionModel} from "../v1.0/V1ExpressionModel";
+import {ErrorCode} from "./validation";
 
 export class CommandLineParsers {
 
@@ -29,6 +30,10 @@ export class CommandLineParsers {
                 .then(res => {
                     return new CommandLinePart(prefix + separator + res, cmdType, loc);
                 }, err => {
+                    if (err.type === "warning" && err.code === ErrorCode.EXPR_LINTER_WARNING) {
+                        const evaluation = err.payload.evaluation == null ? "" : err.payload.evaluation;
+                        return new CommandLinePart(prefix + separator + evaluation, cmdType, loc);
+                    }
                     return new CommandLinePart(`<${err.type} at ${err.loc}>`, err.type, loc);
                 });
         }
@@ -62,6 +67,10 @@ export class CommandLineParsers {
                     .then(res => {
                         return new CommandLinePart(prefix + separator + res, type, loc);
                     }, err => {
+                        if (err.type === "warning" && err.code === ErrorCode.EXPR_LINTER_WARNING) {
+                            const evaluation = err.payload.evaluation == null ? "" : err.payload.evaluation;
+                            return new CommandLinePart(prefix + separator + evaluation, type, loc);
+                        }
                         return new CommandLinePart(`<${err.type} at ${err.loc}>`, err.type, loc);
                     });
             }
@@ -111,6 +120,10 @@ export class CommandLineParsers {
                 .then(res => {
                     return new CommandLinePart(prefix + separator + res, cmdType, loc);
                 }, err => {
+                    if (err.type === "warning" && err.code === ErrorCode.EXPR_LINTER_WARNING) {
+                        const evaluation = err.payload.evaluation == null ? "" : err.payload.evaluation;
+                        return new CommandLinePart(prefix + separator + evaluation, cmdType, loc);
+                    }
                     return new CommandLinePart(`<${err.type} at ${err.loc}>`, err.type, loc);
                 });
         }
@@ -135,6 +148,9 @@ export class CommandLineParsers {
         return expr.evaluate(context).then(res => {
             return res === undefined ? "" : res;
         }, err => {
+            if (err.type === "warning" && err.code === ErrorCode.EXPR_LINTER_WARNING) {
+                return err.payload.evaluation == null ? "" : err.payload.evaluation;
+            }
             return new CommandLinePart(`<${err.type} at ${err.loc}>`, err.type, loc);
         });
     }

--- a/src/models/helpers/ExpressionEvaluator.ts
+++ b/src/models/helpers/ExpressionEvaluator.ts
@@ -23,9 +23,9 @@ export class ExpressionEvaluator {
                     switch (token.type) {
                         case "func":
                             return ExpressionEvaluator.evaluateExpression("(function() {" + this.libraries.join("\n\n") + "\n\n"
-                                + token.value + "})()", context);
+                                + token.value + "})()", context, version);
                         case "expr":
-                            return ExpressionEvaluator.evaluateExpression(this.libraries.join("\n\n") + "\n\n" + token.value, context);
+                            return ExpressionEvaluator.evaluateExpression(this.libraries.join("\n\n") + "\n\n" + token.value, context, version);
                         case "literal":
                             return new Promise(res => res(token.value));
                     }
@@ -50,7 +50,7 @@ export class ExpressionEvaluator {
                     ? "(function()" + expr.script + ")()"
                     : expr.script;
 
-                return ExpressionEvaluator.evaluateExpression(script, context);
+                return ExpressionEvaluator.evaluateExpression(script, context, version);
             }
         }
 

--- a/src/models/helpers/validation/ErrorCode.ts
+++ b/src/models/helpers/validation/ErrorCode.ts
@@ -11,6 +11,7 @@ export enum ErrorCode {
     EXPR_REFERENCE          = 202,
     EXPR_TYPE               = 203,
     EXPR_NOT_JSON           = 204,
+    EXPR_LINTER_WARNING     = 205,
 
     CONNECTION_ALL          = 300,
     CONNECTION_TYPE         = 301,


### PR DESCRIPTION
- add new warning type EXPR_LINTER_WARNING for expression evaluation
- expression result are visible in command line when this warning occurs
- ReferenceError and TypeError warning for v1.0 are now errors
- expression version can now be used in evaluateExpression() callback