### PR TITLE
fix: stdin should be ordered before stdout

### DIFF
--- a/src/models/helpers/CommandLineUtils.ts
+++ b/src/models/helpers/CommandLineUtils.ts
@@ -31,10 +31,10 @@ export const generateCommandLineParts = (tool: CommandLineToolModel, jobInputs, 
         });
     });
 
-    const stdOutPromise = CommandLinePrepare.prepare(tool.stdout, flatJobInputs, tool.getContext(), tool.stdout.loc, "stdout");
     const stdInPromise  = CommandLinePrepare.prepare(tool.stdin, flatJobInputs, tool.getContext(), tool.stdin.loc, "stdin");
+    const stdOutPromise = CommandLinePrepare.prepare(tool.stdout, flatJobInputs, tool.getContext(), tool.stdout.loc, "stdout");
 
-    return Promise.all([].concat(baseCmdPromise, inputPromise, stdOutPromise, stdInPromise)).then((parts: CommandLinePart[]) => {
+    return Promise.all([].concat(baseCmdPromise, inputPromise, stdInPromise, stdOutPromise)).then((parts: CommandLinePart[]) => {
         return parts.filter(part => part !== null);
     });
 };

--- a/src/models/v1.0/V1CommandLineToolModel.spec.ts
+++ b/src/models/v1.0/V1CommandLineToolModel.spec.ts
@@ -180,6 +180,18 @@ describe("V1CommandLineToolModel", () => {
                 expect(res[0].value).to.equal("<error at document.arguments[0]>");
             }).then(done, done);
         });
+
+        it('should generate valid command line input/output redirection',  (done) => {
+            const model = new V1CommandLineToolModel(<any> {
+                baseCommand: 'sort',
+                stdin: 'unsorted.txt',
+                stdout: 'sorted.txt'
+            });
+
+            model.generateCommandLine().then(res => {
+                expect(res).to.equal("sort < unsorted.txt > sorted.txt");
+            }).then(done, done)
+        });
     });
 
     describe("serialize", () => {


### PR DESCRIPTION
The expected command line generated with `generateCommandLine()` should be:
`cmd < stdin > stdout` 

but result was 
`cmd > stdout < stdin`