### PR TITLE
Fix record type nested props in CommandLineTool for v1.0

### DIFF
--- a/src/models/v1.0/V1CommandInputParameterModel.ts
+++ b/src/models/v1.0/V1CommandInputParameterModel.ts
@@ -69,7 +69,7 @@ export class V1CommandInputParameterModel extends CommandInputParameterModel imp
         if (this.label) base.label = this.label;
         if (this.description) base.doc = this.description;
 
-        if (isFileType(this) && this.fileTypes.length && !this.isField) {
+        if (isFileType(this) && this.fileTypes.length) {
             (base as CommandInputParameter)["sbg:fileTypes"] = this.fileTypes.join(", ");
         }
 

--- a/src/models/v1.0/V1CommandInputParameterModel.ts
+++ b/src/models/v1.0/V1CommandInputParameterModel.ts
@@ -73,11 +73,11 @@ export class V1CommandInputParameterModel extends CommandInputParameterModel imp
             (base as CommandInputParameter)["sbg:fileTypes"] = this.fileTypes.join(", ");
         }
 
-        if (this.streamable !== undefined && !this.isField) {
+        if (this.streamable !== undefined) {
             (base as CommandInputParameter).streamable = this.streamable;
         }
 
-        if (this.secondaryFiles && this.secondaryFiles.length && !this.isField) {
+        if (this.secondaryFiles && this.secondaryFiles.length) {
             (base as CommandInputParameter).secondaryFiles = this.secondaryFiles.map(f => f.serialize()).filter(f => !!f);
         }
 

--- a/src/models/v1.0/V1CommandOutputParameterModel.ts
+++ b/src/models/v1.0/V1CommandOutputParameterModel.ts
@@ -56,7 +56,7 @@ export class V1CommandOutputParameterModel extends CommandOutputParameterModel i
             }
         }
 
-        if (!this.isField && this.secondaryFiles.length && (this.type.type === "File" || this.type.items === "File")) {
+        if (this.secondaryFiles.length && (this.type.type === "File" || this.type.items === "File")) {
             (<CommandOutputParameter> base).secondaryFiles = this.secondaryFiles.map(f => f.serialize()).filter(f => !!f);
         }
 
@@ -64,7 +64,7 @@ export class V1CommandOutputParameterModel extends CommandOutputParameterModel i
             (<CommandOutputParameter> base)["sbg:fileTypes"] = this.fileTypes.join(", ");
         }
 
-        if (!this.isField && this.streamable) {
+        if (this.streamable) {
             (<CommandOutputParameter> base).streamable = this.streamable;
         }
 

--- a/src/models/v1.0/V1CommandOutputParameterModel.ts
+++ b/src/models/v1.0/V1CommandOutputParameterModel.ts
@@ -60,7 +60,7 @@ export class V1CommandOutputParameterModel extends CommandOutputParameterModel i
             (<CommandOutputParameter> base).secondaryFiles = this.secondaryFiles.map(f => f.serialize()).filter(f => !!f);
         }
 
-        if (isFileType(this) && !this.isField && this.fileTypes.length) {
+        if (isFileType(this) && this.fileTypes.length) {
             (<CommandOutputParameter> base)["sbg:fileTypes"] = this.fileTypes.join(", ");
         }
 


### PR DESCRIPTION
`CommandLineTool` fields `CommandInputRecordField` and `CommandOutputRecordField` should by updated CWL specification implement two properties (`secondaryFiles`, `streamable`) and one custom (`sbg:fileTypes`) property.

These missing properties are the cause of the mistake in CWL specification v1.0
This specification is later fixed in v1.1

https://www.commonwl.org/v1.1/CommandLineTool.html#CommandInputRecordField
https://www.commonwl.org/v1.1/CommandLineTool.html#CommandOutputRecordField