### PR TITLE
Revert "fix: CommandInput[Output]RecordField should have secondaryFil…

### DIFF
--- a/src/models/v1.0/V1CommandInputParameterModel.ts
+++ b/src/models/v1.0/V1CommandInputParameterModel.ts
@@ -73,11 +73,11 @@ export class V1CommandInputParameterModel extends CommandInputParameterModel imp
             (base as CommandInputParameter)["sbg:fileTypes"] = this.fileTypes.join(", ");
         }
 
-        if (this.streamable !== undefined) {
+        if (this.streamable !== undefined && !this.isField) {
             (base as CommandInputParameter).streamable = this.streamable;
         }
 
-        if (this.secondaryFiles && this.secondaryFiles.length) {
+        if (this.secondaryFiles && this.secondaryFiles.length && !this.isField) {
             (base as CommandInputParameter).secondaryFiles = this.secondaryFiles.map(f => f.serialize()).filter(f => !!f);
         }
 

--- a/src/models/v1.0/V1CommandOutputParameterModel.ts
+++ b/src/models/v1.0/V1CommandOutputParameterModel.ts
@@ -56,7 +56,7 @@ export class V1CommandOutputParameterModel extends CommandOutputParameterModel i
             }
         }
 
-        if (this.secondaryFiles.length && (this.type.type === "File" || this.type.items === "File")) {
+        if (!this.isField && this.secondaryFiles.length && (this.type.type === "File" || this.type.items === "File")) {
             (<CommandOutputParameter> base).secondaryFiles = this.secondaryFiles.map(f => f.serialize()).filter(f => !!f);
         }
 
@@ -64,7 +64,7 @@ export class V1CommandOutputParameterModel extends CommandOutputParameterModel i
             (<CommandOutputParameter> base)["sbg:fileTypes"] = this.fileTypes.join(", ");
         }
 
-        if (this.streamable) {
+        if (!this.isField && this.streamable) {
             (<CommandOutputParameter> base).streamable = this.streamable;
         }
 


### PR DESCRIPTION
**Revert breaking change**

Properties `secondaryFiles` and `streamable` in CommandInput[Output]RecordField should not exist in CWL v1.0, they are later added in CWL 1.1 spec and should stay that way

Check #90 pull request for more details