### PR TITLE
Input/output nodes should have inheritable doc instead of description for v1.0

### DIFF
--- a/src/models/generic/WorkflowModel.ts
+++ b/src/models/generic/WorkflowModel.ts
@@ -1194,8 +1194,8 @@ export abstract class WorkflowModel extends ValidationBase implements Serializab
         const inputParam = Object.assign({
             id: this.getNextAvailableId(`${STEP_OUTPUT_CONNECTION_PREFIX}${inPort.id}/${inPort.id}`, true), // might change later in case input is already taken
             type: inPort.type ? inPort.type.serialize() : "null",
-            description: inPort.description ? inPort.description : undefined,
-            doc: inPort["doc"] ? inPort["doc"] : undefined,
+            description: (inPort["doc"] === undefined) && inPort.description ? inPort.description : undefined,
+            doc: inPort.description ? inPort.description : inPort["doc"],
             label: inPort.label,
             ["sbg:fileTypes"]: inPort.fileTypes,
             inputBinding: inPort["inputBinding"],
@@ -1260,8 +1260,8 @@ export abstract class WorkflowModel extends ValidationBase implements Serializab
             type: outPort.type ? outPort.type.serialize() : "null",
             ["sbg:fileTypes"]: outPort.fileTypes,
             secondaryFiles: outPort["secondaryFiles"],
-            description: outPort.description ? outPort.description : undefined,
-            doc: outPort["doc"] ? outPort["doc"] : undefined,
+            description: (outPort["doc"] === undefined) && outPort.description ? outPort.description : undefined,
+            doc: outPort.description ? outPort.description : outPort["doc"],
             label: outPort.label,
         }, opts.customProps) as OutputParameter;
 

--- a/src/models/generic/WorkflowModel.ts
+++ b/src/models/generic/WorkflowModel.ts
@@ -1194,7 +1194,8 @@ export abstract class WorkflowModel extends ValidationBase implements Serializab
         const inputParam = Object.assign({
             id: this.getNextAvailableId(`${STEP_OUTPUT_CONNECTION_PREFIX}${inPort.id}/${inPort.id}`, true), // might change later in case input is already taken
             type: inPort.type ? inPort.type.serialize() : "null",
-            description: inPort.description,
+            description: inPort.description ? inPort.description : undefined,
+            doc: inPort["doc"] ? inPort["doc"] : undefined,
             label: inPort.label,
             ["sbg:fileTypes"]: inPort.fileTypes,
             inputBinding: inPort["inputBinding"],
@@ -1259,7 +1260,8 @@ export abstract class WorkflowModel extends ValidationBase implements Serializab
             type: outPort.type ? outPort.type.serialize() : "null",
             ["sbg:fileTypes"]: outPort.fileTypes,
             secondaryFiles: outPort["secondaryFiles"],
-            description: outPort.description,
+            description: outPort.description ? outPort.description : undefined,
+            doc: outPort["doc"] ? outPort["doc"] : undefined,
             label: outPort.label,
         }, opts.customProps) as OutputParameter;
 

--- a/src/models/v1.0/V1WorkflowInputParameterModel.ts
+++ b/src/models/v1.0/V1WorkflowInputParameterModel.ts
@@ -18,6 +18,7 @@ import {ExpressionModel} from "../generic/ExpressionModel";
 export class V1WorkflowInputParameterModel extends WorkflowInputParameterModel {
     public streamable?: boolean;
     public inputBinding?: V1CommandLineBindingModel;
+    public doc?: string;
 
     constructor(input?: InputParameter | RecordField, loc?: string, eventHub?: EventHub) {
         super(loc, eventHub);
@@ -31,6 +32,7 @@ export class V1WorkflowInputParameterModel extends WorkflowInputParameterModel {
 
         this._label      = attr.label;
         this.description = ensureArray(attr.doc).join("\n\n");
+        this.doc         = this.description;
 
         this.id      = (<InputParameter> attr).id || (<RecordField> attr).name;
         this.isField = !!(<RecordField> attr).name;

--- a/src/models/v1.0/V1WorkflowOutputParameterModel.ts
+++ b/src/models/v1.0/V1WorkflowOutputParameterModel.ts
@@ -17,6 +17,7 @@ export class V1WorkflowOutputParameterModel extends WorkflowOutputParameterModel
     linkMerge: LinkMergeMethod;
     streamable?: boolean;
     outputBinding?: V1CommandOutputBindingModel;
+    doc?: string;
 
     constructor(output?: WorkflowOutputParameter, loc?: string, eventHub?: EventHub) {
         super(loc, eventHub);
@@ -46,6 +47,7 @@ export class V1WorkflowOutputParameterModel extends WorkflowOutputParameterModel
 
         this._label      = output.label;
         this.description = ensureArray(output.doc).join("\n\n");
+        this.doc         = this.description;
 
         if (!this.isField) {
             this.fileTypes = commaSeparatedToArray((output as WorkflowOutputParameter)["sbg:fileTypes"]);

--- a/src/models/v1.0/V1WorkflowStepInputModel.ts
+++ b/src/models/v1.0/V1WorkflowStepInputModel.ts
@@ -15,6 +15,8 @@ export class V1WorkflowStepInputModel extends WorkflowStepInputModel implements 
      */
     isVisible = false;
 
+    doc: string | string[];
+
     constructor(stepInput?: WorkflowStepInput, step?: V1StepModel, loc?: string) {
         super(loc);
         this.parentStep = step;
@@ -78,7 +80,7 @@ export class V1WorkflowStepInputModel extends WorkflowStepInputModel implements 
         if (!this.type) this.type = new ParameterTypeModel(null);
         this.type.hasDirectoryType = true;
 
-        this.description = attr["doc"];
+        this.doc         = attr["doc"];
         this.label       = attr["label"];
 
         this.fileTypes = attr["fileTypes"];

--- a/src/models/v1.0/V1WorkflowStepOutputModel.ts
+++ b/src/models/v1.0/V1WorkflowStepOutputModel.ts
@@ -12,6 +12,7 @@ export class V1WorkflowStepOutputModel extends WorkflowStepOutputModel implement
     }
 
     customProps: any;
+    doc: string | string[];
 
     serialize(): WorkflowStepOutput {
         return {
@@ -32,7 +33,7 @@ export class V1WorkflowStepOutputModel extends WorkflowStepOutputModel implement
         if (!this.type) this.type = new ParameterTypeModel(null);
         this.type.hasDirectoryType = true;
 
-        this.description = output["doc"];
+        this.doc = output["doc"];
         this.label = output["label"];
         this.secondaryFiles = output["secondaryFiles"];
 


### PR DESCRIPTION
- v1.0 should have "doc" prop instead of "description" in CWL for InputParameter and WorkflowOutputParameter as per spec:
    - https://www.commonwl.org/v1.0/Workflow.html#InputParameter 
    - https://www.commonwl.org/v1.0/Workflow.html#WorkflowOutputParameter

- doc should be inherited and mapped and exposed as description (stay the same as before)
- when exposed "description" changes in model it should be reflected in "doc" prop in CWL