### PR TITLE
Cannot resolve vm

### DIFF
--- a/src/models/d2sb/SBDraft2CommandInputParameterModel.spec.ts
+++ b/src/models/d2sb/SBDraft2CommandInputParameterModel.spec.ts
@@ -2,7 +2,7 @@ import {SBDraft2CommandInputParameterModel} from "./SBDraft2CommandInputParamete
 import {expect} from "chai";
 import {CommandInputParameter} from "../../mappings/d2sb/CommandInputParameter";
 import {ExpressionClass} from "../../mappings/d2sb/Expression";
-import {JSExecutor} from "../helpers/JSExecutor";
+import {JSExecutor} from "../../tests/shared/JSExecutor";
 import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
 
 describe("SBDraft2CommandInputParameterModel d2sb", () => {

--- a/src/models/d2sb/SBDraft2CommandLineBindingModel.spec.ts
+++ b/src/models/d2sb/SBDraft2CommandLineBindingModel.spec.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import {CommandLineBinding} from "../../mappings/d2sb/CommandLineBinding";
 import {ExpressionClass} from "../../mappings/d2sb/Expression";
 import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
-import {JSExecutor} from "../helpers/JSExecutor";
+import {JSExecutor} from "../../tests/shared/JSExecutor";
 import {SBDraft2CommandLineBindingModel} from "./SBDraft2CommandLineBindingModel";
 
 describe("SBDraft2CommandLineBindingModel d2sb", () => {

--- a/src/models/d2sb/SBDraft2CommandLineToolModel.spec.ts
+++ b/src/models/d2sb/SBDraft2CommandLineToolModel.spec.ts
@@ -10,7 +10,7 @@ import * as BfctoolsAnnotate from "../../tests/apps/bfctools-annotate-sbg";
 import * as BindingTestTool from "../../tests/apps/binding-test-tool";
 import {CommandLineTool} from "../../mappings/d2sb/CommandLineTool";
 import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
-import {JSExecutor} from "../helpers/JSExecutor";
+import {JSExecutor} from "../../tests/shared/JSExecutor";
 
 should();
 

--- a/src/models/d2sb/SBDraft2CommandOutputParameterModel.spec.ts
+++ b/src/models/d2sb/SBDraft2CommandOutputParameterModel.spec.ts
@@ -3,7 +3,7 @@ import {CommandOutputBinding} from "../../mappings/d2sb/CommandOutputBinding";
 import {ExpressionClass} from "../../mappings/d2sb/Expression";
 import {testCommandOutputBindingSerialization} from '../../tests/shared/model';
 import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
-import {JSExecutor} from "../helpers/JSExecutor";
+import {JSExecutor} from "../../tests/shared/JSExecutor";
 import {SBDraft2CommandLineToolModel} from "./SBDraft2CommandLineToolModel";
 import {SBDraft2CommandOutputBindingModel} from "./SBDraft2CommandOutputBindingModel";
 import {SBDraft2CommandOutputParameterModel} from "./SBDraft2CommandOutputParameterModel";

--- a/src/models/d2sb/SBDraft2ExpressionModel.spec.ts
+++ b/src/models/d2sb/SBDraft2ExpressionModel.spec.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import {SBDraft2ExpressionModel} from "./SBDraft2ExpressionModel";
 import {Expression} from "../../mappings/d2sb/Expression";
 import {ExpressionClass} from "../../mappings/d2sb/Expression";
-import {JSExecutor} from "../helpers/JSExecutor";
+import {JSExecutor} from "../../tests/shared/JSExecutor";
 import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
 
 describe("SBDraft2ExpressionModel", () => {

--- a/src/models/helpers/index.ts
+++ b/src/models/helpers/index.ts
@@ -1,6 +1,5 @@
 export * from "./ExpressionEvaluator";
 export * from "./CommandLinePart";
-export * from "./JSExecutor";
 export * from "./Graph";
 export * from "./TypeResolver";
 export * from "./constants";

--- a/src/models/v1.0/V1CommandLineToolModel.spec.ts
+++ b/src/models/v1.0/V1CommandLineToolModel.spec.ts
@@ -3,12 +3,11 @@ import {CommandLineTool} from "../../mappings/v1.0/CommandLineTool";
 import {testNamespaces} from "../../tests/shared/model";
 import {CommandLinePart} from "../helpers/CommandLinePart";
 import {ExpressionEvaluator} from "../helpers/ExpressionEvaluator";
-import {JSExecutor} from "../helpers/JSExecutor";
+import {JSExecutor} from "../../tests/shared/JSExecutor";
 import {V1CommandInputParameterModel} from "./V1CommandInputParameterModel";
 import {V1CommandLineToolModel} from "./V1CommandLineToolModel";
 import {V1CommandOutputParameterModel} from "./V1CommandOutputParameterModel";
 import {V1ExpressionModel} from "./V1ExpressionModel";
-import {CommandLineParsers} from "../helpers/CommandLineParsers";
 
 function runTest(app: CommandLineTool, job: any, expected: CommandLinePart[], done) {
     let model = new V1CommandLineToolModel(app, "document");

--- a/src/tests/shared/JSExecutor.ts
+++ b/src/tests/shared/JSExecutor.ts
@@ -1,4 +1,3 @@
-declare function require(name: string);
 const vm = require('vm');
 
 export class JSExecutor {


### PR DESCRIPTION
Remove JSExecutor from models, because it's needed only for the tests

This closes #77