### PR TITLE
Fix / getContext fails when getting source

### DIFF
--- a/src/models/v1.0/V1WorkflowModel.ts
+++ b/src/models/v1.0/V1WorkflowModel.ts
@@ -106,6 +106,8 @@ export class V1WorkflowModel extends WorkflowModel implements Serializable<Workf
 
                 let source = this.graph.getVertexData(this.getSourceConnectionId(sourceId));
 
+                if (!source) { return }
+
                 const sourceType = source.type;
                 // If has parent step then source is step, otherwise its input
                 source = source.parentStep || source;


### PR DESCRIPTION
- happens if the input source is missing from definition