### PR TITLE
Feat / shellQuote should be true by defaull

### DIFF
--- a/src/models/generic/CommandArgumentModel.ts
+++ b/src/models/generic/CommandArgumentModel.ts
@@ -40,6 +40,10 @@ export abstract class CommandArgumentModel extends ValidationBase implements Ser
         return this.binding ? (<any> this.binding).shellQuote : undefined;
     }
 
+    set shellQuote(val: boolean) {
+        this.binding.shellQuote = val;
+    }
+
     customProps: any = {};
 
     constructor(loc?: string, protected eventHub?: EventHub) {

--- a/src/models/v1.0/V1CommandLineBindingModel.ts
+++ b/src/models/v1.0/V1CommandLineBindingModel.ts
@@ -9,7 +9,7 @@ import {ErrorCode} from "../helpers/validation/ErrorCode";
 
 export class V1CommandLineBindingModel extends CommandLineBindingModel implements Serializable<CommandLineBinding> {
     public valueFrom: V1ExpressionModel;
-    public shellQuote = false;
+    public shellQuote = true;
     public hasSecondaryFiles = false;
     public hasShellQuote     = true;
 


### PR DESCRIPTION
From spec:
"If ShellCommandRequirement is in the requirements for the current command, this controls whether the value is quoted on the command line (default is true)."