### PR TITLE
Fix / generateMockJobData only if input is found

### DIFF
--- a/src/models/generic/WorkflowModel.ts
+++ b/src/models/generic/WorkflowModel.ts
@@ -250,8 +250,12 @@ export abstract class WorkflowModel extends ValidationBase implements Serializab
                 .replace("document", ""); // so loc is relative to root
 
             const input = fetchByLoc(this, loc);
-            context = { self: JobHelper.generateMockJobData(input) };
 
+            if (!input) {
+                return expression.validate();
+            }
+
+            context = { self: JobHelper.generateMockJobData(input) };
             return expression.validate(context);
         }
 


### PR DESCRIPTION
This shouldn't be a problem and input should always exist if it's loc (location) exists. But there is a flaw in loc mechanism.